### PR TITLE
Completa Passo 4.1: Backend (Gestão de Firmware)

### DIFF
--- a/backend/app/Http/Controllers/FirmwareController.php
+++ b/backend/app/Http/Controllers/FirmwareController.php
@@ -3,8 +3,9 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-// use App\Models\Firmware; // Uncomment when Model is created
-// use Illuminate\Support\Facades\Storage; // Uncomment for file operations
+use App\Models\Firmware;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class FirmwareController extends Controller
 {
@@ -13,8 +14,16 @@ class FirmwareController extends Controller
      */
     public function index()
     {
-        // Placeholder
-        return response()->json(['message' => 'FirmwareController@index placeholder']);
+        $firmwares = Firmware::orderBy('version', 'desc')->paginate(15);
+        return view('admin.firmwares.index', compact('firmwares'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('admin.firmwares.create');
     }
 
     /**
@@ -22,23 +31,89 @@ class FirmwareController extends Controller
      */
     public function store(Request $request)
     {
-        // Placeholder: Validate and store firmware
-        // $request->validate([
-        //     'version' => 'required|string|unique:firmwares,version',
-        //     'firmware_file' => 'required|file|mimetypes:application/octet-stream,application/macbinary,application/bin', // Adjust mimetypes as needed
-        //     'description' => 'nullable|string',
-        // ]);
-        // $path = $request->file('firmware_file')->store('firmwares');
-        // Firmware::create([
-        //     'version' => $request->version,
-        //     'filename' => $path,
-        //     'description' => $request->description,
-        //     'size' => $request->file('firmware_file')->getSize(),
-        //     'is_active' => false, // Or true, depending on logic
-        // ]);
-        // return response()->json(['message' => 'Firmware uploaded successfully'], 201);
-        return response()->json(['message' => 'FirmwareController@store placeholder'], 201);
+        $validatedData = $request->validate([
+            'version' => 'required|string|max:50|unique:firmwares,version',
+            'firmware_file' => 'required|file|mimetypes:application/octet-stream,application/x-binary,application/macbinary,application/x-macbinary', // .bin files, added one more for macbinary
+            'description' => 'nullable|string|max:1000',
+        ]);
+
+        if ($request->hasFile('firmware_file') && $request->file('firmware_file')->isValid()) {
+            $file = $request->file('firmware_file');
+            $originalExtension = $file->getClientOriginalExtension();
+            if(empty($originalExtension)) $originalExtension = 'bin'; // Default to .bin if no extension
+
+            $filename = 'firmware_v' . Str::slug($validatedData['version']) . '.' . $originalExtension;
+            $path = $file->storeAs('firmwares_storage', $filename, 'local');
+
+            Firmware::create([
+                'version' => $validatedData['version'],
+                'filename' => $path,
+                'description' => $validatedData['description'],
+                'size' => $file->getSize(),
+                'is_active' => false,
+            ]);
+
+            return redirect()->route('admin.firmwares.index')->with('success', 'Firmware carregado com sucesso!');
+        }
+
+        return back()->with('error', 'Falha no upload do arquivo de firmware. Verifique o arquivo e tente novamente.')->withInput();
     }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Firmware $firmware)
+    {
+        return view('admin.firmwares.edit', compact('firmware'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Firmware $firmware)
+    {
+        $validatedData = $request->validate([
+            'version' => 'required|string|max:50|unique:firmwares,version,' . $firmware->id,
+            'description' => 'nullable|string|max:1000',
+        ]);
+
+        $firmware->update($validatedData);
+        return redirect()->route('admin.firmwares.index')->with('success', 'Detalhes do Firmware atualizados!');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Firmware $firmware)
+    {
+        try {
+            if (Storage::disk('local')->exists($firmware->filename)) {
+                Storage::disk('local')->delete($firmware->filename);
+            }
+            $firmware->delete();
+            return redirect()->route('admin.firmwares.index')->with('success', 'Firmware excluído com sucesso!');
+        } catch (\Exception $e) {
+            // Log::error("Erro ao excluir firmware {$firmware->id}: " . $e->getMessage()); // Descomentar com Log facade
+            return redirect()->route('admin.firmwares.index')->with('error', 'Erro ao excluir firmware.');
+        }
+    }
+
+    /**
+     * Set the specified firmware as active.
+     */
+    public function setActive(Firmware $firmware)
+    {
+        DB::transaction(function () use ($firmware) { // Usar transação para garantir atomicidade
+            Firmware::where('is_active', true)->update(['is_active' => false]);
+            $firmware->is_active = true;
+            $firmware->save();
+        });
+
+        return redirect()->route('admin.firmwares.index')->with('success', "Firmware v{$firmware->version} marcado como ativo!");
+    }
+
+
+    // Os métodos checkForUpdate e download são para a API e serão implementados no Passo 4.2
 
     /**
      * API endpoint for ESP32 to check for updates.

--- a/backend/resources/views/admin/firmwares/_form.blade.php
+++ b/backend/resources/views/admin/firmwares/_form.blade.php
@@ -1,0 +1,42 @@
+@csrf
+<div>
+    <label for="version">Versão:</label><br>
+    <input type="text" id="version" name="version" value="{{ old('version', $firmware->version ?? '') }}" required maxlength="50" {{ isset($firmware) ? 'readonly' : '' }}>
+    @error('version')
+        <div style="color: red;">{{ $message }}</div>
+    @enderror
+    @if(isset($firmware))
+        <small>A versão não pode ser alterada após a criação.</small>
+    @endif
+</div>
+<br>
+<div>
+    <label for="description">Descrição (Opcional):</label><br>
+    <textarea id="description" name="description" rows="3" maxlength="1000">{{ old('description', $firmware->description ?? '') }}</textarea>
+    @error('description')
+        <div style="color: red;">{{ $message }}</div>
+    @enderror
+</div>
+<br>
+
+@if(!isset($firmware)) // Mostrar campo de upload de arquivo apenas na criação
+<div>
+    <label for="firmware_file">Arquivo Firmware (.bin):</label><br>
+    <input type="file" id="firmware_file" name="firmware_file" required accept=".bin,application/octet-stream,application/x-binary,application/macbinary">
+    @error('firmware_file')
+        <div style="color: red;">{{ $message }}</div>
+    @enderror
+</div>
+<br>
+@else
+<div>
+    <p><strong>Arquivo:</strong> {{ $firmware->filename }} (Tamanho: {{ number_format($firmware->size) }} bytes)</p>
+    <small>Para alterar o arquivo de firmware, por favor, exclua este registro e faça um novo upload.</small>
+</div>
+<br>
+@endif
+
+<div>
+    <button type="submit">{{ $submitButtonText ?? 'Salvar' }}</button>
+    <a href="{{ route('admin.firmwares.index') }}">Cancelar</a>
+</div>

--- a/backend/resources/views/admin/firmwares/create.blade.php
+++ b/backend/resources/views/admin/firmwares/create.blade.php
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Upload Novo Firmware</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], input[type="file"], textarea { margin-bottom: 10px; width: 300px; padding: 8px; border: 1px solid #ccc; }
+        textarea { height: 80px; }
+        .error { color: red; font-size: 0.9em; }
+        button, a { padding: 10px 15px; text-decoration: none; border: 1px solid #ccc; background-color: #eee; cursor: pointer; }
+        button[type="submit"] { background-color: #28a745; color: white; }
+        a { color: #007bff; }
+    </style>
+</head>
+<body>
+    <h1>Upload Novo Firmware</h1>
+
+    <form action="{{ route('admin.firmwares.store') }}" method="POST" enctype="multipart/form-data">
+        @include('admin.firmwares._form', ['submitButtonText' => 'Fazer Upload'])
+    </form>
+</body>
+</html>

--- a/backend/resources/views/admin/firmwares/edit.blade.php
+++ b/backend/resources/views/admin/firmwares/edit.blade.php
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Editar Firmware - v{{ $firmware->version }}</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], textarea { margin-bottom: 10px; width: 300px; padding: 8px; border: 1px solid #ccc; }
+        textarea { height: 80px; }
+        .error { color: red; font-size: 0.9em; }
+        button, a { padding: 10px 15px; text-decoration: none; border: 1px solid #ccc; background-color: #eee; cursor: pointer; }
+        button[type="submit"] { background-color: #007bff; color: white; }
+        a { color: #333; }
+    </style>
+</head>
+<body>
+    <h1>Editar Firmware: v{{ $firmware->version }}</h1>
+
+    <form action="{{ route('admin.firmwares.update', $firmware) }}" method="POST">
+        @method('PUT')
+        @include('admin.firmwares._form', ['submitButtonText' => 'Atualizar Detalhes', 'firmware' => $firmware])
+    </form>
+</body>
+</html>

--- a/backend/resources/views/admin/firmwares/index.blade.php
+++ b/backend/resources/views/admin/firmwares/index.blade.php
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gerenciar Firmwares</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+        .actions a, .actions button { margin-right: 5px; text-decoration: none; padding: 5px 10px; border: 1px solid #ccc; background-color: #eee; cursor: pointer; font-size: 0.9em; }
+        .actions button.delete { color: red; }
+        .actions button.set-active { color: green; }
+        .alert-success { padding: 15px; background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; margin-bottom: 20px; }
+        .alert-error { padding: 15px; background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; margin-bottom: 20px; }
+        .create-link { margin-bottom: 20px; display: inline-block; padding: 10px 15px; background-color: #007bff; color: white; text-decoration: none; }
+        .is-active { font-weight: bold; color: green; }
+    </style>
+</head>
+<body>
+    <h1>Gerenciar Firmwares</h1>
+
+    <a href="{{ route('admin.firmwares.create') }}" class="create-link">Upload Novo Firmware</a>
+
+    @if (session('success'))
+        <div class="alert-success">
+            {{ session('success') }}
+        </div>
+    @endif
+    @if (session('error'))
+        <div class="alert-error">
+            {{ session('error') }}
+        </div>
+    @endif
+
+    <table>
+        <thead>
+            <tr>
+                <th>Versão</th>
+                <th>Descrição</th>
+                <th>Tamanho (bytes)</th>
+                <th>Data Upload</th>
+                <th>Ativo?</th>
+                <th>Ações</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($firmwares as $firmware)
+                <tr>
+                    <td>{{ $firmware->version }}</td>
+                    <td>{{ $firmware->description ?: '-' }}</td>
+                    <td>{{ number_format($firmware->size) }}</td>
+                    <td>{{ $firmware->created_at->format('d/m/Y H:i') }}</td>
+                    <td class="{{ $firmware->is_active ? 'is-active' : '' }}">{{ $firmware->is_active ? 'Sim' : 'Não' }}</td>
+                    <td class="actions">
+                        @if (!$firmware->is_active)
+                            <form action="{{ route('admin.firmwares.set-active', $firmware) }}" method="POST" style="display:inline;">
+                                @csrf
+                                @method('PATCH')
+                                <button type="submit" class="set-active">Marcar como Ativo</button>
+                            </form>
+                        @endif
+                        <a href="{{ route('admin.firmwares.edit', $firmware) }}">Editar</a>
+                        <form action="{{ route('admin.firmwares.destroy', $firmware) }}" method="POST" style="display:inline;" onsubmit="return confirm('Tem certeza que deseja excluir este firmware? O arquivo físico também será removido.');">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="delete">Excluir</button>
+                        </form>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="6">Nenhum firmware encontrado.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    @if ($firmwares->hasPages())
+        <div>
+            {{ $firmwares->links() }}
+        </div>
+    @endif
+
+</body>
+</html>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -37,6 +37,7 @@ Route::prefix('admin')->middleware('auth')->group(function () {
     // Access Log Routes
     Route::get('access-logs', [App\Http\Controllers\AccessLogController::class, 'index'])->name('admin.access-logs.index');
 
-    // Firmware Management Routes (placeholders)
-    // Route::resource('firmwares', App\Http\Controllers\FirmwareController::class)->names('admin.firmwares'); // Exemplo se fosse resource
+    // Firmware Management Routes
+    Route::resource('firmwares', App\Http\Controllers\FirmwareController::class, ['as' => 'admin'])->except(['show']);
+    Route::patch('firmwares/{firmware}/set-active', [App\Http\Controllers\FirmwareController::class, 'setActive'])->name('admin.firmwares.set-active');
 });


### PR DESCRIPTION
- Adiciona rotas web para CRUD de firmwares e para marcar como ativo.
- Implementa métodos no FirmwareController para gerenciar firmwares (index, create, store, edit, update, destroy, setActive).
- Cria views Blade (index, create, edit, _form) para a interface de gerenciamento de firmwares.
- FirmwareController atualizado para usar views e redirecionamentos.