### PR TITLE
Completa Passo 4.2: API Endpoints para OTA

### DIFF
--- a/backend/app/Http/Controllers/FirmwareController.php
+++ b/backend/app/Http/Controllers/FirmwareController.php
@@ -117,32 +117,66 @@ class FirmwareController extends Controller
 
     /**
      * API endpoint for ESP32 to check for updates.
+     * Query parameters: current_version (e.g., "1.0.0"), board_id (optional, e.g., MAC Address)
      */
     public function checkForUpdate(Request $request)
     {
-        // Placeholder:
-        // $currentVersion = $request->query('current_version');
-        // $boardId = $request->query('board_id'); // Could be used for targeted updates
-        // $latestFirmware = Firmware::where('is_active', true)->orderBy('version', 'desc')->first();
-        // if ($latestFirmware && version_compare($latestFirmware->version, $currentVersion, '>')) {
-        //     return response()->json([
-        //         'update_available' => true,
-        //         'new_version' => $latestFirmware->version,
-        //         'download_url' => route('firmware.download', ['firmware_id' => $latestFirmware->id]) // Assuming a named route
-        //     ]);
-        // }
-        // return response()->json(['update_available' => false]);
-        return response()->json(['message' => 'FirmwareController@checkForUpdate placeholder']);
+        $request->validate([
+            'current_version' => 'required|string|max:50',
+            'board_id' => 'nullable|string|max:17', // MAC Address XX:XX:XX:XX:XX:XX
+        ]);
+
+        $currentVersion = $request->input('current_version');
+        // $boardId = $request->input('board_id'); // Pode ser usado no futuro para firmwares específicos por placa
+
+        // Encontrar o firmware ativo mais recente (poderia haver apenas um ativo)
+        // Se houver múltiplos ativos, pegar o de maior versão.
+        $activeFirmware = Firmware::where('is_active', true)
+                                  ->orderBy('version', 'desc') // Ordena por versão para pegar o mais novo se houver múltiplos ativos
+                                  ->first();
+
+        if (!$activeFirmware) {
+            return response()->json(['update_available' => false, 'reason' => 'No active firmware found on server.']);
+        }
+
+        // Comparar versões (version_compare é útil para semver)
+        if (version_compare($activeFirmware->version, $currentVersion, '>')) {
+            return response()->json([
+                'update_available' => true,
+                'new_version' => $activeFirmware->version,
+                'description' => $activeFirmware->description,
+                'size_bytes' => $activeFirmware->size,
+                // Gerar URL de download absoluta. Usar o nome da rota definido em api.php.
+                'download_url' => route('api.firmware.download', ['firmware' => $activeFirmware->id], true),
+            ]);
+        }
+
+        return response()->json(['update_available' => false, 'current_version_is_latest' => true]);
     }
 
     /**
      * API endpoint for ESP32 to download firmware.
      */
-    public function download(string $firmware_id)
+    public function download(Firmware $firmware) // Route Model Binding
     {
-        // Placeholder:
-        // $firmware = Firmware::findOrFail($firmware_id);
-        // return Storage::download($firmware->filename, 'firmware.bin');
-        return response()->json(['message' => "FirmwareController@download placeholder for ID: $firmware_id"]);
+        if (!$firmware->is_active) {
+             // Por segurança, permitir apenas download de firmwares ativos,
+             // ou remover esta verificação se o ESP já recebeu o ID de um firmware específico do /check
+             // Se o /check só retorna IDs de firmwares ativos, esta verificação é uma dupla checagem.
+            // return response()->json(['error' => 'Firmware not active or not found.'], 403);
+        }
+
+        // O nome do arquivo no storage é $firmware->filename
+        // O nome que o cliente vai baixar pode ser genérico como 'firmware.bin' ou específico.
+        $downloadName = 'firmware_v' . Str::slug($firmware->version) . '.bin'; // Ex: firmware_v1-0-1.bin
+
+        if (Storage::disk('local')->exists($firmware->filename)) {
+            return Storage::disk('local')->download($firmware->filename, $downloadName, [
+                'Content-Type' => 'application/octet-stream',
+            ]);
+        } else {
+            // Log::error("Arquivo de firmware não encontrado no storage: {$firmware->filename} para Firmware ID: {$firmware->id}");
+            return response()->json(['error' => 'Arquivo de firmware não encontrado.'], 404);
+        }
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -4,7 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AccessLogController;
 use App\Http\Controllers\VehicleController;
-// Use App\Http\Controllers\FirmwareController; // Uncomment when controller is created
+use App\Http\Controllers\FirmwareController;
 
 /*
 |--------------------------------------------------------------------------
@@ -30,7 +30,11 @@ Route::prefix('v1')->group(function () { // Versioning the API
     // Endpoint for ESP32 to validate vehicle authorization
     Route::get('/vehicles/authorize/{lora_id}', [VehicleController::class, 'checkAuthorization'])->name('api.vehicles.authorize');
 
-    // Endpoints for ESP32 OTA Firmware Updates (placeholders for Fase 4)
-    // Route::get('/firmware/check', [FirmwareController::class, 'checkForUpdate'])->name('api.firmware.check');
-    // Route::get('/firmware/download/{firmware_id}', [FirmwareController::class, 'download'])->name('api.firmware.download');
+    // Endpoints for ESP32 OTA Firmware Updates
+    Route::get('/firmware/check', [FirmwareController::class, 'checkForUpdate'])->name('api.firmware.check');
+    // Usar {firmware} para Route Model Binding se o ID for o primary key.
+    // Se o ESP32 for enviar a VERSÃO para download, precisaremos de uma rota diferente ou lógica no controller.
+    // Por simplicidade, vamos assumir que o ESP32 recebe um ID (ou nome de arquivo único) do endpoint /check.
+    // O plano original diz {firmware_id}, então vamos manter assim.
+    Route::get('/firmware/download/{firmware}', [FirmwareController::class, 'download'])->name('api.firmware.download');
 });


### PR DESCRIPTION
- Define rotas API para /firmware/check e /firmware/download.
- Implementa checkForUpdate no FirmwareController para verificar se há novo firmware ativo, comparando versões e retornando URL de download.
- Implementa download no FirmwareController para servir o arquivo de firmware solicitado.