### PR TITLE
feat: Melhorar UI/UX para gestão de permissões de veículos

### DIFF
--- a/backend/app/Http/Controllers/Api/DataController.php
+++ b/backend/app/Http/Controllers/Api/DataController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Company;
+use App\Models\Site;
+use App\Models\Barrier;
+use Illuminate\Support\Arr;
+
+class DataController extends Controller
+{
+    public function getSitesForCompanies(Request $request, $company_ids_str)
+    {
+        $company_ids = explode(',', $company_ids_str);
+        $company_ids = array_filter(array_map('intval', $company_ids)); // Sanitizar
+
+        if (empty($company_ids)) {
+            return response()->json([]);
+        }
+
+        $sites = Site::whereIn('company_id', $company_ids)
+                     ->where('is_active', true) // Considerar apenas ativos
+                     ->orderBy('name')
+                     ->get(['id', 'name', 'company_id']); // Incluir company_id para possível agrupamento no frontend
+
+        return response()->json($sites);
+    }
+
+    public function getBarriersForSites(Request $request, $site_ids_str)
+    {
+        $site_ids = explode(',', $site_ids_str);
+        $site_ids = array_filter(array_map('intval', $site_ids)); // Sanitizar
+
+        if (empty($site_ids)) {
+            return response()->json([]);
+        }
+
+        $barriers = Barrier::whereIn('site_id', $site_ids)
+                           ->where('is_active', true) // Considerar apenas ativos
+                           ->orderBy('name')
+                           ->get(['id', 'name', 'site_id']); // Incluir site_id para possível agrupamento
+
+        return response()->json($barriers);
+    }
+}

--- a/backend/app/Http/Controllers/VehicleController.php
+++ b/backend/app/Http/Controllers/VehicleController.php
@@ -29,7 +29,9 @@ class VehicleController extends Controller
         //     $query->where('is_authorized', (bool)$request->is_authorized_filter);
         // }
 
-        $vehicles = $query->paginate(15)->withQueryString(); // Manter filtros na paginação
+        $vehicles = $query->withCount(['companyPermissions', 'sitePermissions', 'barrierPermissions'])
+                           ->paginate(15)
+                           ->withQueryString(); // Manter filtros na paginação
 
         return view('admin.vehicles.index', compact('vehicles'));
     }

--- a/backend/app/Models/Vehicle.php
+++ b/backend/app/Models/Vehicle.php
@@ -60,4 +60,28 @@ class Vehicle extends Model
                     })
                     ->exists();
     }
+
+    /**
+     * Get only the company permissions for the vehicle.
+     */
+    public function companyPermissions(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->permissions()->where('permissible_type', Company::class);
+    }
+
+    /**
+     * Get only the site permissions for the vehicle.
+     */
+    public function sitePermissions(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->permissions()->where('permissible_type', Site::class);
+    }
+
+    /**
+     * Get only the barrier permissions for the vehicle.
+     */
+    public function barrierPermissions(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->permissions()->where('permissible_type', Barrier::class);
+    }
 }

--- a/backend/resources/views/admin/vehicles/_form.blade.php
+++ b/backend/resources/views/admin/vehicles/_form.blade.php
@@ -33,35 +33,189 @@
 @endif
 
 {{-- Permissões para Sites --}}
-@if(isset($sites) && $sites->count())
+{{-- Div para carregar Sites dinamicamente --}}
 <div style="margin-top: 15px;">
     <h4>Sites (Locais)</h4>
-    @foreach($sites as $site)
-        <label>
-            <input type="checkbox" name="permissions[sites][]" value="{{ $site->id }}"
-                   {{ (isset($vehiclePermissions['sites']) && in_array($site->id, $vehiclePermissions['sites'])) ? 'checked' : '' }}>
-            {{ $site->name }} (Empresa: {{ $site->company->name ?? 'N/A' }})
-        </label>
-    @endforeach
+    <div id="sites-permission-list">
+        {{-- Sites selecionados inicialmente (modo de edição) serão populados aqui pelo JS ou mantidos se já renderizados --}}
+        {{-- Ou podemos deixar o PHP renderizar os selecionados e o JS adiciona/remove os outros --}}
+        @if(isset($vehicle) && !empty($vehiclePermissions['sites']))
+            @php
+                // Carregar os modelos de Site que estão de facto selecionados para este veículo
+                // Isto é importante para que, mesmo que não pertençam às empresas inicialmente selecionadas (se o user desmarcar uma empresa),
+                // eles ainda apareçam como selecionados até serem explicitamente desmarcados.
+                // No entanto, a lógica do JS irá RECARREGAR os sites com base nas empresas selecionadas.
+                // Uma abordagem mais simples é deixar o JS lidar com a população inicial dos sites e barreiras
+                // com base nas empresas/sites selecionados.
+                // Por agora, vamos deixar o JS popular tudo dinamicamente.
+            @endphp
+        @endif
+        <p>Selecione uma ou mais empresas para ver os sites disponíveis.</p>
+    </div>
 </div>
-@endif
 
-{{-- Permissões para Barreiras --}}
-@if(isset($barriers) && $barriers->count())
+{{-- Div para carregar Barreiras dinamicamente --}}
 <div style="margin-top: 15px;">
     <h4>Barreiras (Pontos de Controle)</h4>
-    @foreach($barriers as $barrier)
-        <label>
-            <input type="checkbox" name="permissions[barriers][]" value="{{ $barrier->id }}"
-                   {{ (isset($vehiclePermissions['barriers']) && in_array($barrier->id, $vehiclePermissions['barriers'])) ? 'checked' : '' }}>
-            {{ $barrier->name }} (Site: {{ $barrier->site->name ?? 'N/A' }}, Empresa: {{ $barrier->site->company->name ?? 'N/A' }})
-        </label>
-    @endforeach
+    <div id="barriers-permission-list">
+        <p>Selecione um ou mais sites para ver as barreiras disponíveis.</p>
+    </div>
 </div>
-@endif
 
 
 <div style="margin-top: 20px;">
     <button type="submit">{{ $submitButtonText ?? 'Salvar' }}</button>
     <a href="{{ route('admin.vehicles.index') }}">Cancelar</a>
 </div>
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const companyCheckboxes = document.querySelectorAll('input[name="permissions[companies][]"]');
+    const sitesPermissionList = document.getElementById('sites-permission-list');
+    const barriersPermissionList = document.getElementById('barriers-permission-list');
+
+    // Permissões que vieram do controller (para o modo de edição)
+    const existingPermissions = {
+        sites: @json($vehiclePermissions['sites'] ?? []),
+        barriers: @json($vehiclePermissions['barriers'] ?? [])
+    };
+
+    async function fetchSitesForCompanies(companyIds) {
+        if (!companyIds || companyIds.length === 0) {
+            renderSites([]);
+            renderBarriers([]); // Limpa barreiras se nenhuma empresa estiver selecionada
+            return;
+        }
+        try {
+            const response = await fetch(`{{ url('api/v1/companies') }}/${companyIds.join(',')}/sites`, {
+                headers: {
+                    'Accept': 'application/json',
+                    // Adicionar X-CSRF-TOKEN se necessário para APIs com estado e middleware web, mas para Sanctum API GET geralmente não é.
+                    // 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                }
+            });
+            if (!response.ok) {
+                console.error('Erro ao buscar sites:', response.statusText);
+                renderSites([]); return;
+            }
+            const sites = await response.json();
+            renderSites(sites);
+        } catch (error) {
+            console.error('Erro na requisição de sites:', error);
+            renderSites([]);
+        }
+    }
+
+    async function fetchBarriersForSites(siteIds) {
+        if (!siteIds || siteIds.length === 0) {
+            renderBarriers([]);
+            return;
+        }
+        try {
+            const response = await fetch(`{{ url('api/v1/sites') }}/${siteIds.join(',')}/barriers`, {
+                headers: { 'Accept': 'application/json' }
+            });
+            if (!response.ok) {
+                console.error('Erro ao buscar barreiras:', response.statusText);
+                renderBarriers([]); return;
+            }
+            const barriers = await response.json();
+            renderBarriers(barriers);
+        } catch (error) {
+            console.error('Erro na requisição de barreiras:', error);
+            renderBarriers([]);
+        }
+    }
+
+    function renderSites(sites) {
+        sitesPermissionList.innerHTML = ''; // Limpa a lista
+        if (sites.length === 0) {
+            sitesPermissionList.innerHTML = '<p>Nenhum site encontrado para as empresas selecionadas ou nenhuma empresa selecionada.</p>';
+            return;
+        }
+        sites.forEach(site => {
+            const isChecked = existingPermissions.sites.includes(site.id);
+            // Se um site estava selecionado mas a empresa dele foi desmarcada, ele não aparecerá mais aqui,
+            // o que é o comportamento esperado (a permissão será removida no backend ao salvar).
+            const label = document.createElement('label');
+            label.style.display = 'block'; // Para melhor formatação
+            label.innerHTML = `
+                <input type="checkbox" name="permissions[sites][]" value="${site.id}" ${isChecked ? 'checked' : ''} data-company-id="${site.company_id}">
+                ${site.name} (Empresa ID: ${site.company_id})
+            `; // TODO: Melhorar para mostrar nome da empresa se disponível no JSON
+            sitesPermissionList.appendChild(label);
+        });
+        // Adiciona listeners às novas checkboxes de sites
+        addSiteCheckboxListeners();
+        // Após renderizar os sites, verifica se algum está selecionado e carrega as barreiras
+        updateBarriersBasedOnSelectedSites();
+    }
+
+    function renderBarriers(barriers) {
+        barriersPermissionList.innerHTML = ''; // Limpa a lista
+        if (barriers.length === 0) {
+            barriersPermissionList.innerHTML = '<p>Nenhuma barreira encontrada para os sites selecionados ou nenhum site selecionado.</p>';
+            return;
+        }
+        barriers.forEach(barrier => {
+            const isChecked = existingPermissions.barriers.includes(barrier.id);
+            const label = document.createElement('label');
+            label.style.display = 'block';
+            label.innerHTML = `
+                <input type="checkbox" name="permissions[barriers][]" value="${barrier.id}" ${isChecked ? 'checked' : ''} data-site-id="${barrier.site_id}">
+                ${barrier.name} (Site ID: ${barrier.site_id})
+            `; // TODO: Melhorar para mostrar nome do site se disponível no JSON
+            barriersPermissionList.appendChild(label);
+        });
+    }
+
+    function getSelectedCompanyIds() {
+        return Array.from(companyCheckboxes)
+                    .filter(cb => cb.checked)
+                    .map(cb => cb.value);
+    }
+
+    function getSelectedSiteIds() {
+        const currentSiteCheckboxes = sitesPermissionList.querySelectorAll('input[name="permissions[sites][]"]');
+        return Array.from(currentSiteCheckboxes)
+                    .filter(cb => cb.checked)
+                    .map(cb => cb.value);
+    }
+
+    function updateSitesBasedOnSelectedCompanies() {
+        const selectedCompanyIds = getSelectedCompanyIds();
+        fetchSitesForCompanies(selectedCompanyIds);
+    }
+
+    function updateBarriersBasedOnSelectedSites() {
+        const selectedSiteIds = getSelectedSiteIds();
+        fetchBarriersForSites(selectedSiteIds);
+    }
+
+    companyCheckboxes.forEach(checkbox => {
+        checkbox.addEventListener('change', updateSitesBasedOnSelectedCompanies);
+    });
+
+    function addSiteCheckboxListeners() {
+        const currentSiteCheckboxes = sitesPermissionList.querySelectorAll('input[name="permissions[sites][]"]');
+        currentSiteCheckboxes.forEach(checkbox => {
+            // Remove listener antigo para evitar duplicação se esta função for chamada múltiplas vezes
+            checkbox.removeEventListener('change', updateBarriersBasedOnSelectedSites);
+            checkbox.addEventListener('change', updateBarriersBasedOnSelectedSites);
+        });
+    }
+
+    // Carga Inicial (Modo de Edição)
+    // Se houver empresas selecionadas na carga, busca os sites.
+    // A função renderSites então chamará updateBarriersBasedOnSelectedSites se sites forem selecionados.
+    if (getSelectedCompanyIds().length > 0) {
+        updateSitesBasedOnSelectedCompanies();
+    } else {
+        // Garante que as listas estejam vazias/com placeholder se nenhuma empresa estiver selecionada inicialmente.
+        renderSites([]);
+        renderBarriers([]);
+    }
+});
+</script>
+@endpush

--- a/backend/resources/views/admin/vehicles/index.blade.php
+++ b/backend/resources/views/admin/vehicles/index.blade.php
@@ -52,7 +52,7 @@
             <tr>
                 <th>ID LoRa</th>
                 <th>Nome</th>
-                {{-- Coluna Autorizado? Removida --}}
+                <th>Permissões (E|S|B)</th>
                 <th>Criado em</th>
                 <th>Ações</th>
             </tr>
@@ -62,7 +62,11 @@
                 <tr>
                     <td>{{ $vehicle->lora_id }}</td>
                     <td>{{ $vehicle->name ?: '-' }}</td>
-                    {{-- <td>{{ $vehicle->is_authorized ? 'Sim' : 'Não' }}</td> --}}
+                    <td>
+                        E:{{ $vehicle->company_permissions_count ?? 0 }} |
+                        S:{{ $vehicle->site_permissions_count ?? 0 }} |
+                        B:{{ $vehicle->barrier_permissions_count ?? 0 }}
+                    </td>
                     <td>{{ $vehicle->created_at->format('d/m/Y H:i') }}</td>
                     <td class="actions">
                         <a href="{{ route('admin.vehicles.edit', $vehicle) }}">Editar Permissões</a>
@@ -75,7 +79,7 @@
                 </tr>
             @empty
                 <tr>
-                    <td colspan="4">Nenhum veículo encontrado.</td>
+                    <td colspan="5">Nenhum veículo encontrado.</td>
                 </tr>
             @endforelse
         </tbody>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -37,4 +37,8 @@ Route::prefix('v1')->middleware('auth:sanctum')->group(function () { // Proteger
     // Por simplicidade, vamos assumir que o ESP32 recebe um ID (ou nome de arquivo único) do endpoint /check.
     // O plano original diz {firmware_id}, então vamos manter assim.
     Route::get('/firmware/download/{firmware}', [FirmwareController::class, 'download'])->name('api.firmware.download');
+
+    // Endpoints para carregar dados para formulários dinâmicos (ex: permissões de veículos)
+    Route::get('companies/{company_ids_str}/sites', [\App\Http\Controllers\Api\DataController::class, 'getSitesForCompanies'])->name('api.v1.sites_for_companies');
+    Route::get('sites/{site_ids_str}/barriers', [\App\Http\Controllers\Api\DataController::class, 'getBarriersForSites'])->name('api.v1.barriers_for_sites');
 });


### PR DESCRIPTION
Este commit introduz duas melhorias principais na interface do utilizador para a gestão de permissões de veículos:

1.  **Dropdowns Dinâmicos no Formulário de Veículos:**
    *   Implementados endpoints de API (`/api/v1/companies/{ids}/sites` e `/api/v1/sites/{ids}/barriers`) para fornecer dados de sites e barreiras filtrados.
    *   Adicionado JavaScript ao formulário de criação/edição de veículos (`_form.blade.php`) para:
        *   Atualizar dinamicamente as checkboxes de permissão para Sites com base nas Empresas selecionadas.
        *   Atualizar dinamicamente as checkboxes de permissão para Barreiras com base nos Sites selecionados.
        *   Garantir que, no modo de edição, as permissões existentes sejam corretamente refletidas e os campos dinâmicos populados na carga inicial.

2.  **Visualização Resumida de Permissões na Listagem de Veículos:**
    *   Adicionadas relações `companyPermissions`, `sitePermissions`, e `barrierPermissions` ao modelo `Vehicle` para facilitar a contagem de permissões por tipo.
    *   `VehicleController@index` modificado para carregar estas contagens (`company_permissions_count`, etc.) usando `withCount`.
    *   A view `admin.vehicles.index.blade.php` agora exibe uma nova coluna "Permissões (E|S|B)" que mostra um resumo das contagens de permissões para cada veículo (ex: "E:1 | S:2 | B:0").

Estas alterações melhoram significativamente a usabilidade ao gerir as permissões de acesso dos veículos, tornando o processo mais intuitivo e fornecendo melhor feedback visual.