### PR TITLE
feat: Implementar fundação do RBAC e gestão de utilizadores

### DIFF
--- a/backend/app/Http/Controllers/BarrierController.php
+++ b/backend/app/Http/Controllers/BarrierController.php
@@ -16,48 +16,120 @@ class BarrierController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Barrier::with('site.company')->orderBy('site_id')->orderBy('name', 'asc');
+        $user = auth()->user();
+        // SuperAdmin (Gate::before), CompanyAdmin, SiteManager.
+        if ($user->hasRole('company-admin')) {
+            $this->authorize('barriers:view-own-company');
+        } elseif ($user->hasRole('site-manager')) {
+            $this->authorize('barriers:view-assigned-site');
+        } else {
+            $this->authorize('barriers:view-any'); // SuperAdmin ou outros papéis
+        }
 
+        $query = Barrier::with('site.company'); // orderBy será no final
+
+        // Aplicar escopo baseado no papel
+        if ($user->isSuperAdmin()) {
+            $sites_for_filter = Site::orderBy('name')->get();
+            $companies_for_filter = Company::orderBy('name')->get();
+        } elseif ($user->hasRole('company-admin') && $user->company_id) {
+            $query->whereHas('site', function ($q) use ($user) {
+                $q->where('company_id', $user->company_id);
+            });
+            $sites_for_filter = Site::where('company_id', $user->company_id)->orderBy('name')->get();
+            $companies_for_filter = Company::where('id', $user->company_id)->orderBy('name')->get();
+        } elseif ($user->hasRole('site-manager') && $user->company_id) {
+            // SiteManager vê barreiras de sites da sua company_id.
+            // Idealmente, filtraria por sites especificamente atribuídos a ele.
+            // $query->whereIn('site_id', $user->getManagedSiteIds()); // Se existisse
+            $query->whereHas('site', function ($q) use ($user) {
+                $q->where('company_id', $user->company_id);
+                // $q->whereIn('id', $user->getManagedSiteIds()); // Se existisse
+            });
+            // $sites_for_filter = Site::whereIn('id', $user->getManagedSiteIds())->orderBy('name')->get(); // Ideal
+            $sites_for_filter = Site::where('company_id', $user->company_id)->orderBy('name')->get(); // Simplificado
+            $companies_for_filter = Company::where('id', $user->company_id)->orderBy('name')->get();
+        } else {
+            $query->whereRaw('1 = 0'); // Query vazia para outros papéis
+            $sites_for_filter = collect();
+            $companies_for_filter = collect();
+        }
+
+        // Aplicar filtros do request
         if ($request->filled('name_filter')) {
             $query->where('name', 'like', '%' . $request->name_filter . '%');
         }
         if ($request->filled('base_station_mac_filter')) {
             $query->where('base_station_mac_address', 'like', '%' . $request->base_station_mac_filter . '%');
         }
+
+        // Filtro de site_id
         if ($request->filled('site_filter')) {
-            $query->where('site_id', $request->site_filter);
+            $site_filter_id = $request->site_filter;
+            // Validar se o site_filter_id está dentro do escopo do utilizador (se não for SuperAdmin)
+            if (!$user->isSuperAdmin() && $user->company_id) {
+                $allowed_site = Site::where('id', $site_filter_id)->where('company_id', $user->company_id)->exists();
+                // Para SiteManager, verificar se $site_filter_id é um dos seus sites geridos.
+                if ($allowed_site) { // Simplificado: se pertence à empresa do user
+                    $query->where('site_id', $site_filter_id);
+                } else {
+                    // Não aplicar filtro ou logar tentativa, pois a query base já protege.
+                    // Para evitar resultados inesperados, pode-se até forçar a query a não retornar nada se o filtro for inválido.
+                     $query->whereRaw('1 = 0'); // Filtro inválido para o escopo do user
+                }
+            } else if ($user->isSuperAdmin()){ // SuperAdmin pode filtrar por qualquer site
+                $query->where('site_id', $site_filter_id);
+            }
         }
-        // Filtro por empresa (indireto, através do site)
+
+        // Filtro de company_id (indireto)
         if ($request->filled('company_filter')) {
-            $companyId = $request->company_filter;
-            $query->whereHas('site', function ($q) use ($companyId) {
-                $q->where('company_id', $companyId);
-            });
+            $company_filter_id = $request->company_filter;
+            if ($user->isSuperAdmin()) {
+                $query->whereHas('site', function ($q) use ($company_filter_id) {
+                    $q->where('company_id', $company_filter_id);
+                });
+            } elseif ($user->company_id && $company_filter_id == $user->company_id) {
+                // A query base já filtra pela empresa do user, este filtro é redundante mas inofensivo se for a mesma empresa.
+                // Não é preciso adicionar $query->whereHas de novo se a query base já o faz.
+            } elseif ($user->company_id && $company_filter_id != $user->company_id) {
+                // Tentativa de filtrar por outra empresa não permitida.
+                $query->whereRaw('1 = 0'); // Filtro inválido para o escopo do user
+            }
         }
+
         if ($request->filled('is_active_filter') && $request->is_active_filter !== 'all') {
             $query->where('is_active', (bool)$request->is_active_filter);
         }
 
-        $barriers = $query->withCount('accessLogs')->paginate(15)->withQueryString(); // Adiciona contagem de logs
-        $sites_for_filter = Site::orderBy('name')->get(); // TODO: Considerar filtrar sites pela empresa selecionada, se houver
-        $companies_for_filter = Company::orderBy('name')->get();
+        $query->orderBy('site_id')->orderBy('name', 'asc');
+        $barriers = $query->withCount('accessLogs')->paginate(15)->withQueryString();
 
+        // Determinar currentSite e currentCompany para breadcrumbs/títulos
         $currentSiteFromController = null;
         $currentCompanyFromController = null;
-
-        // Prioriza o filtro de site, pois ele contém a empresa
         $siteIdParam = $request->input('site_filter', $request->input('site_id'));
-        if ($siteIdParam) {
-            $currentSiteFromController = Site::with('company')->find($siteIdParam);
-            if ($currentSiteFromController) {
-                $currentCompanyFromController = $currentSiteFromController->company;
-            }
-        } else {
-            // Se não há filtro de site, verifica se há filtro de empresa
-            $companyIdParam = $request->input('company_filter', $request->input('company_id'));
-            if ($companyIdParam) {
+        $companyIdParam = $request->input('company_filter', $request->input('company_id'));
+
+        if ($user->isSuperAdmin()) {
+            if ($siteIdParam) {
+                $currentSiteFromController = Site::with('company')->find($siteIdParam);
+                if ($currentSiteFromController) $currentCompanyFromController = $currentSiteFromController->company;
+            } elseif ($companyIdParam) {
                 $currentCompanyFromController = Company::find($companyIdParam);
             }
+        } else if ($user->company_id) {
+            // Para CompanyAdmin/SiteManager, currentCompany é sempre a sua.
+            $currentCompanyFromController = $companies_for_filter->first(); // Deve ser a única na coleção
+            if ($siteIdParam) {
+                // Verificar se o site pertence à empresa do utilizador
+                $site_check = Site::where('id', $siteIdParam)->where('company_id', $user->company_id)->first();
+                if ($site_check) {
+                     // Para SiteManager, verificar se é um dos seus sites geridos
+                    $currentSiteFromController = $site_check;
+                }
+            }
+            // Se não houver filtro de site, $currentSiteFromController permanece null, o que é ok.
         }
 
         return view('admin.barriers.index', compact('barriers', 'sites_for_filter', 'companies_for_filter', 'currentSiteFromController', 'currentCompanyFromController'));
@@ -68,12 +140,39 @@ class BarrierController extends Controller
      */
     public function create()
     {
-        $sites_grouped = Company::with(['sites' => function ($query) {
+        $user = auth()->user();
+        // SuperAdmin (Gate::before), CompanyAdmin, SiteManager.
+        if ($user->hasRole('company-admin')) {
+            $this->authorize('barriers:create-own-company-site');
+        } elseif ($user->hasRole('site-manager')) {
+            $this->authorize('barriers:create-assigned-site');
+        } else {
+            // Para SuperAdmin, Gate::before permite. Se outro papel criar, precisa de uma permissão como 'barriers:create-any'
+            // Por agora, vamos assumir que apenas os acima ou super-admin podem criar.
+            // Se um super-admin está a criar, ele pode escolher qualquer site.
+            // Se um company-admin, sites da sua empresa. Se site-manager, sites atribuídos.
+            $this->authorize('barriers:create-own-company-site'); // Ou uma permissão mais genérica se existir
+        }
+
+        // Filtrar sites_grouped com base no papel do utilizador
+        $companies_query = Company::query()->where('is_active', true);
+
+        if ($user->hasRole('company-admin') && $user->company_id) {
+            $companies_query->where('id', $user->company_id);
+        } elseif ($user->hasRole('site-manager') && $user->company_id) {
+            // SiteManager só deve ver sites da sua própria empresa para selecionar
+            $companies_query->where('id', $user->company_id);
+            // Adicionalmente, poderia filtrar para apenas os sites que ele gere, se essa lógica existir.
+            // Por agora, ele pode criar barreiras em qualquer site da sua empresa.
+        }
+        // SuperAdmin vê todas as empresas.
+
+        $sites_grouped = $companies_query->with(['sites' => function ($query) {
             $query->where('is_active', true)->orderBy('name');
-        }])->where('is_active', true)->orderBy('name')->get()
+        }])->orderBy('name')->get()
         ->mapWithKeys(function ($company) {
             return [$company->name => $company->sites->pluck('name', 'id')];
-        })->filter(function ($sitesInCompany) { // Renomeado para clareza
+        })->filter(function ($sitesInCompany) {
             return $sitesInCompany->isNotEmpty();
         });
 
@@ -85,6 +184,33 @@ class BarrierController extends Controller
      */
     public function store(Request $request)
     {
+        $user = auth()->user();
+        $site = Site::find($request->site_id);
+
+        if (!$site) {
+            abort(404, 'Site not found.');
+        }
+
+        if ($user->isSuperAdmin()) {
+            // SuperAdmin pode criar em qualquer site (Gate::before já deve ter permitido a intenção)
+            // Apenas valida se ele tem uma permissão genérica de criar, se não for coberto pelo before.
+            // $this->authorize('barriers:create-any'); // ou similar
+        } elseif ($user->hasRole('company-admin')) {
+            if ($site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION. Company Admin can only create barriers for their own company sites.');
+            }
+            $this->authorize('barriers:create-own-company-site');
+        } elseif ($user->hasRole('site-manager')) {
+            // Assumindo que site-manager tem company_id e só pode gerir sites dessa empresa.
+            // A verificação de se $site é um dos "assigned" seria mais granular aqui.
+            if ($site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION. Site Manager can only create barriers for their assigned company sites.');
+            }
+            $this->authorize('barriers:create-assigned-site');
+        } else {
+            abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
         $validatedData = $request->validate([
             'site_id' => 'required|exists:sites,id',
             'name' => [
@@ -107,14 +233,45 @@ class BarrierController extends Controller
      */
     public function edit(Barrier $barrier)
     {
-        $sites_grouped = Company::with(['sites' => function ($query) {
+        $user = auth()->user();
+        $site = $barrier->site; // O site ao qual a barreira pertence
+
+        if ($user->isSuperAdmin()) {
+            $this->authorize('barriers:update-any');
+        } elseif ($user->hasRole('company-admin')) {
+            if ($site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            $this->authorize('barriers:update-own-company-site');
+        } elseif ($user->hasRole('site-manager')) {
+            if ($site->company_id !== $user->company_id) { // Verificação base de empresa
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            // Adicionar lógica para verificar se $site é um dos "assigned" ao site-manager.
+            $this->authorize('barriers:update-assigned-site');
+        } else {
+            abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
+        // Filtrar sites_grouped para o dropdown, semelhante ao create()
+        $companies_query = Company::query()->where('is_active', true);
+        if ($user->hasRole('company-admin') && $user->company_id) {
+            $companies_query->where('id', $user->company_id);
+        } elseif ($user->hasRole('site-manager') && $user->company_id) {
+            $companies_query->where('id', $user->company_id);
+            // SiteManager não deve poder mudar a barreira para um site que não gere.
+            // O dropdown de sites deve ser limitado aos seus sites.
+        }
+
+        $sites_grouped = $companies_query->with(['sites' => function ($query) {
             $query->where('is_active', true)->orderBy('name');
-        }])->where('is_active', true)->orderBy('name')->get()
+        }])->orderBy('name')->get()
         ->mapWithKeys(function ($company) {
             return [$company->name => $company->sites->pluck('name', 'id')];
-        })->filter(function ($sitesInCompany) { // Renomeado para clareza
+        })->filter(function ($sitesInCompany) {
             return $sitesInCompany->isNotEmpty();
         });
+
         return view('admin.barriers.edit', compact('barrier', 'sites_grouped'));
     }
 
@@ -123,8 +280,57 @@ class BarrierController extends Controller
      */
     public function update(Request $request, Barrier $barrier)
     {
+        $user = auth()->user();
+        $requested_site = Site::find($request->site_id); // Site para o qual se quer mover/manter a barreira
+
+        if (!$requested_site) {
+            abort(404, 'Target site not found.');
+        }
+
+        // Verificar se o utilizador pode desassociar do site antigo E associar ao novo site.
+        $original_site = $barrier->site;
+
+        // 1. Pode o user editar esta barreira no seu site original?
+        if ($user->isSuperAdmin()) {
+            $this->authorize('barriers:update-any');
+        } elseif ($user->hasRole('company-admin')) {
+            if ($original_site->company_id !== $user->company_id || $requested_site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION. Company Admin can only manage barriers within their own company sites.');
+            }
+            $this->authorize('barriers:update-own-company-site');
+        } elseif ($user->hasRole('site-manager')) {
+            // SiteManager só pode gerir barreiras nos seus sites. Não deve poder mover entre sites a menos que ambos sejam seus.
+            if ($original_site->company_id !== $user->company_id || $requested_site->company_id !== $user->company_id) {
+                 abort(403, 'UNAUTHORIZED ACTION. Site Manager cannot move barriers out of their company.');
+            }
+            // Adicionar verificação se original_site e requested_site são "assigned"
+            if ($original_site->id !== $requested_site->id) { // Se está a tentar mudar de site
+                 // Precisa de permissão para "tirar" do original E para "colocar" no novo.
+                 // Esta lógica pode ser complexa e ideal para uma Policy.
+                 // Por agora, simplificamos: se ele pode editar barreiras nos sites da sua empresa, e ambos os sites são da sua empresa.
+            }
+            $this->authorize('barriers:update-assigned-site');
+        } else {
+            abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
+
         $validatedData = $request->validate([
-            'site_id' => 'required|exists:sites,id',
+            'site_id' => ['required', 'exists:sites,id', function ($attribute, $value, $fail) use ($user, $barrier) {
+                $targetSite = Site::find($value);
+                if ($user->hasRole('company-admin') && $targetSite && $targetSite->company_id != $user->company_id) {
+                    $fail('You can only assign barriers to sites within your own company.');
+                }
+                if ($user->hasRole('site-manager')) {
+                    // SiteManager só pode atribuir a um site que ele gere.
+                    // Esta validação precisa da lista de sites geridos pelo SiteManager.
+                    // Por agora, assumimos que ele só pode operar dentro da sua company_id.
+                    if ($targetSite && $targetSite->company_id != $user->company_id) {
+                        $fail('Site Managers can only assign barriers to sites within their company.');
+                    }
+                    // Idealmente: if (!$user->managesSite($targetSite)) { $fail(...); }
+                }
+            }],
             'name' => [
                 'required', 'string', 'max:255',
                 Rule::unique('barriers')->where(function ($query) use ($request) {
@@ -145,6 +351,26 @@ class BarrierController extends Controller
      */
     public function destroy(Barrier $barrier)
     {
+        $user = auth()->user();
+        $site = $barrier->site;
+
+        if ($user->isSuperAdmin()) {
+            $this->authorize('barriers:delete-any');
+        } elseif ($user->hasRole('company-admin')) {
+            if ($site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            $this->authorize('barriers:delete-own-company-site');
+        } elseif ($user->hasRole('site-manager')) {
+            if ($site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            // Adicionar verificação se $site é um dos "assigned" ao site-manager.
+            $this->authorize('barriers:delete-assigned-site');
+        } else {
+            abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
         try {
             $barrier->delete();
             return redirect()->route('admin.barriers.index')->with('success', 'Barreira excluída com sucesso!');

--- a/backend/app/Http/Controllers/CompanyController.php
+++ b/backend/app/Http/Controllers/CompanyController.php
@@ -13,7 +13,33 @@ class CompanyController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Company::orderBy('name', 'asc');
+        $user = auth()->user();
+        $query = Company::query();
+
+        if ($user->isSuperAdmin()) {
+            // Super Admin pode ver todas as empresas
+            $this->authorize('companies:view-any');
+            // Nenhuma restrição adicional na query
+        } elseif ($user->hasRole('company-admin') && $user->company_id) {
+            // Company Admin só pode ver a sua própria empresa
+            $this->authorize('companies:view-own');
+            $query->where('id', $user->company_id);
+        } else {
+            // Outros papéis (ex: Site Manager) não devem listar empresas desta forma.
+            // A autorização deve apanhar isto. Se chegar aqui, é um erro de lógica de permissão.
+            // Ou, se um SiteManager *pudesse* ver a empresa-mãe, seria uma lógica diferente.
+            // Por agora, negamos acesso se não for SuperAdmin ou CompanyAdmin com company_id.
+            abort(403, 'THIS ACTION IS UNAUTHORIZED.');
+            // Alternativamente, se SiteManager tivesse 'companies:view-own' (para ver a sua empresa mãe)
+            // if ($user->hasRole('site-manager') && $user->company_id) {
+            //     $this->authorize('companies:view-own');
+            //     $query->where('id', $user->company_id);
+            // } else {
+            //     abort(403, 'THIS ACTION IS UNAUTHORIZED.');
+            // }
+        }
+
+        $query->orderBy('name', 'asc');
 
         if ($request->filled('name_filter')) {
             $query->where('name', 'like', '%' . $request->name_filter . '%');
@@ -31,6 +57,7 @@ class CompanyController extends Controller
      */
     public function create()
     {
+        $this->authorize('companies:create');
         return view('admin.companies.create');
     }
 
@@ -39,6 +66,8 @@ class CompanyController extends Controller
      */
     public function store(Request $request)
     {
+        $this->authorize('companies:create');
+
         $validatedData = $request->validate([
             'name' => 'required|string|max:255|unique:companies,name',
             'contact_email' => 'nullable|email|max:255|unique:companies,contact_email',
@@ -55,6 +84,106 @@ class CompanyController extends Controller
      */
     public function edit(Company $company)
     {
+        // Se um company-admin só pode editar a sua, e tem a perm 'companies:update-own'
+        // A Policy ou uma verificação explícita da propriedade seria ideal aqui.
+        // Gate::authorize('update', $company) com uma Policy seria o mais idiomático.
+        // Por agora, verificamos se ele tem a permissão e se a empresa é a dele (lógica a ser adicionada ou assumida).
+        // Para o super-admin, o Gate::before já resolve.
+        // Para company-admin, ele deve ter 'companies:update-own'.
+        // A lógica de que $company é DELE será reforçada no passo de "Adaptar Queries".
+        $this->authorize('companies:update-own', $company); // Este Gate precisa ser definido para aceitar $company ou usar Policy
+                                                       // Se o Gate dinâmico não lidar com o objeto, usar apenas a string:
+                                                       // $this->authorize('companies:update-own');
+                                                       // E a lógica de propriedade virá da query que busca a $company.
+                                                       // Por agora, vamos usar a string e a lógica de propriedade será no passo 4.
+                                                       // Se um company admin tentar editar /admin/companies/OTHER_ID/edit, ele não deve nem carregar a $company.
+                                                       // Se carregar, este authorize deve falhar se não for dele.
+                                                       // Vamos usar a permissão geral e a Policy/lógica de query tratará da propriedade.
+
+        // Para cobrir o caso de super-admin (update-any) e company-admin (update-own)
+        // de forma mais simples com Gates dinâmicos, podemos fazer:
+        if (auth()->user()->hasRole('company-admin')) {
+            $this->authorize('companies:update-own', $company); // Este authorize precisa que o Gate 'companies:update-own'
+                                                              // seja capaz de verificar a propriedade $user->company_id == $company->id
+                                                              // Ou, mais simples, que o company_admin só consiga carregar a sua $company (filtragem de query)
+                                                              // e então só precise de $this->authorize('companies:update-own');
+        } else {
+            $this->authorize('companies:update-any'); // Para super-admin (coberto pelo Gate::before) ou outros papéis com esta perm.
+        }
+        // Simplificando: o Gate::before trata o super-admin.
+        // Para o company-admin, ele terá a perm 'companies:update-own'.
+        // A verificação de que $company é a sua será crucial (passo 4).
+        // Se ele tiver a perm e for a sua company, deve passar.
+        // $this->authorize('update', $company); // Seria o ideal com uma CompanyPolicy
+
+        // Tentativa mais direta com o que temos:
+        // Se o utilizador é company-admin, ele precisa da permissão 'companies:update-own' E $company deve ser a sua.
+        // Se for super-admin, o Gate::before já deu true.
+        // O Gate dinâmico para 'companies:update-own' não verifica a propriedade.
+        // Portanto, a autorização aqui tem que ser mais esperta ou usar uma Policy.
+        // Vamos assumir que o carregamento da $company já é restrito para company-admin (Passo 4)
+        // e aqui apenas verificamos a permissão de "intenção".
+
+        // Abordagem mais segura e simples por agora:
+        // O super-admin (com todas as perms) passa no Gate::before.
+        // O company-admin precisa de 'companies:update-own'. A query no index/edit deve garantir que ele só edita a sua.
+        // Se ele tentar um URL para editar outra company, o Route Model Binding pode falhar (404) ou
+        // este authorize falharia se soubesse da propriedade.
+        // Por agora, confiamos que o Gate::before e a permissão 'companies:update-own' são suficientes,
+        // e a lógica de propriedade será garantida pela query que popula $company para o company-admin.
+        $this->authorize('companies:update-own', $company); // Passar $company para o Gate.
+                                                       // O Gate 'companies:update-own' deve ser capaz de lidar com isto.
+                                                       // Se não, criar um Gate explícito ou Policy.
+                                                       // Vamos REVER o AuthServiceProvider para garantir que isto funcione.
+
+        // O AuthServiceProvider cria Gate::define($permission->name, fn...) que não usa o segundo argumento (modelo).
+        // Portanto, `$this->authorize('companies:update-own', $company)` vai chamar o Gate para 'companies:update-own'
+        // mas o Gate em si não usará $company. A autorização só verificará se o user TEM a string de permissão.
+        // A lógica de propriedade (user->company_id == $company->id) DEVE ser feita ANTES ou DEPOIS, ou numa Policy.
+
+        // Solução temporária mais explícita no controlador:
+        if (auth()->user()->hasRole('company-admin')) {
+            if (auth()->user()->company_id !== $company->id) {
+                abort(403, 'THIS ACTION IS UNAUTHORIZED.'); // Ou redirect com erro
+            }
+            $this->authorize('companies:update-own'); // Ele tem a permissão e a empresa é dele
+        } else {
+            // Para super-admin, o Gate::before já tratou.
+            // Se outro papel tivesse 'companies:update-any', seria aqui.
+            $this->authorize('companies:update-any'); // Isto será coberto pelo Gate::before para super-admin.
+                                                    // Se não houver 'companies:update-any', mas apenas 'companies:update-own'
+                                                    // então um company-admin não passaria aqui se não for dele.
+                                                    // Esta lógica está a ficar complexa aqui, Policies são melhores.
+        }
+        // A linha acima é complexa. Vamos simplificar e assumir que o carregamento da $company
+        // para um company-admin já é seguro (só carrega a sua).
+        // Então só precisamos de verificar a permissão.
+        // E o Gate::before para super-admin trata do acesso total.
+
+        // A melhor abordagem com o sistema de Gates atual:
+        // Super-admin: Passa por Gate::before.
+        // Company-admin: Precisa da permissão 'companies:update-own'. A query que lhe dá $company deve ser segura.
+        // Se ele tentar editar outra $company via URL, o Route Model Binding deve falhar (se filtrado) ou esta auth falha.
+        // Para que 'companies:update-own' funcione para company-admin e não para outros (exceto super-admin),
+        // o Gate::define('companies:update-own', fn...) já faz isso.
+        // A verificação de propriedade (user->company_id == $company->id) é o que falta aqui.
+        // `$this->authorize('update', $company);` usando uma Policy seria o ideal.
+
+        // Vamos usar a permissão 'companies:update-any' para super-admin e
+        // 'companies:update-own' para company-admin. A lógica de propriedade
+        // será verificada explicitamente por agora, até termos Policies.
+        if ($company->id === auth()->user()->company_id || auth()->user()->isSuperAdmin() ) {
+            // Se for a empresa do company_admin OU se for super_admin
+             if (auth()->user()->isSuperAdmin()){
+                $this->authorize('companies:update-any');
+             } else {
+                $this->authorize('companies:update-own');
+             }
+        } else {
+             abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
+
         return view('admin.companies.edit', compact('company'));
     }
 
@@ -63,6 +192,17 @@ class CompanyController extends Controller
      */
     public function update(Request $request, Company $company)
     {
+        // Lógica similar ao edit()
+        if ($company->id === auth()->user()->company_id || auth()->user()->isSuperAdmin() ) {
+             if (auth()->user()->isSuperAdmin()){
+                $this->authorize('companies:update-any');
+             } else {
+                $this->authorize('companies:update-own');
+             }
+        } else {
+             abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
         $validatedData = $request->validate([
             'name' => 'required|string|max:255|unique:companies,name,' . $company->id,
             'contact_email' => 'nullable|email|max:255|unique:companies,contact_email,' . $company->id,
@@ -79,6 +219,9 @@ class CompanyController extends Controller
      */
     public function destroy(Company $company)
     {
+        // Apenas super-admin pode excluir empresas por agora, conforme RBAC_DESIGN.md
+        $this->authorize('companies:delete-any');
+
         try {
             // onDelete('cascade') na migration de 'sites' deve cuidar dos sites e barreiras associadas.
             $company->delete();

--- a/backend/app/Http/Controllers/SiteController.php
+++ b/backend/app/Http/Controllers/SiteController.php
@@ -15,20 +15,70 @@ class SiteController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Site::with('company')->orderBy('company_id')->orderBy('name', 'asc');
+        // SuperAdmin pode ver todos, CompanyAdmin os da sua empresa, SiteManager os seus designados.
+        // A query será adaptada no passo 4. Aqui, verificamos a intenção de ver.
+        // Gate::before trata SuperAdmin. CompanyAdmin e SiteManager precisam da permissão específica.
+        if (auth()->user()->hasRole('company-admin')) {
+            $this->authorize('sites:view-own-company');
+        } elseif (auth()->user()->hasRole('site-manager')) {
+            $this->authorize('sites:view-assigned');
+        } else {
+            $this->authorize('sites:view-any'); // Para SuperAdmin (coberto por Gate::before) ou outros papéis
+        }
 
+        $user = auth()->user();
+        $query = Site::with('company'); // orderBy será adicionado depois
+
+        if ($user->isSuperAdmin()) {
+            // Nenhuma restrição de query para SuperAdmin
+            $companies_for_filter = Company::orderBy('name')->get();
+        } elseif ($user->hasRole('company-admin') && $user->company_id) {
+            $query->where('company_id', $user->company_id);
+            $companies_for_filter = Company::where('id', $user->company_id)->orderBy('name')->get();
+        } elseif ($user->hasRole('site-manager') && $user->company_id) {
+            // SiteManager vê sites da sua company_id.
+            // Idealmente, filtraria por sites especificamente atribuídos a ele.
+            // $query->whereIn('id', $user->getManagedSiteIds()); // Se existisse tal método
+            $query->where('company_id', $user->company_id);
+            $companies_for_filter = Company::where('id', $user->company_id)->orderBy('name')->get();
+        } else {
+            // Se não for nenhum dos acima, não deve ver nada ou a autorização já barrou.
+            // Para segurança, retornamos uma query vazia se chegar aqui por engano.
+            $query->whereRaw('1 = 0'); // Condição sempre falsa
+            $companies_for_filter = collect();
+        }
+
+        // Aplicar filtros do request
         if ($request->filled('name_filter')) {
             $query->where('name', 'like', '%' . $request->name_filter . '%');
         }
+
+        // Se o utilizador NÃO é SuperAdmin, o company_filter deve ser ignorado ou validado
+        // para ser igual ao company_id do utilizador, pois a query já está no escopo.
+        // Se for SuperAdmin, o filtro de empresa é permitido.
         if ($request->filled('company_filter')) {
-            $query->where('company_id', $request->company_filter);
+            if ($user->isSuperAdmin()) {
+                $query->where('company_id', $request->company_filter);
+            } elseif (($user->hasRole('company-admin') || $user->hasRole('site-manager')) && $user->company_id) {
+                // Se o filtro da empresa não for o do próprio utilizador, é uma tentativa inválida.
+                // A query principal já está no escopo, então este filtro é mais para UI.
+                // Se o company_filter for diferente do user->company_id, pode ser um erro ou tentativa de acesso indevido.
+                // No entanto, a query base $query->where('company_id', $user->company_id) já protege.
+                // Apenas precisamos garantir que $companies_for_filter está correto.
+                // O $request->company_filter pode ser usado para o breadcrumb se for válido.
+                if ($request->company_filter != $user->company_id) {
+                    // Logar tentativa ou simplesmente ignorar o filtro, pois a query base já protege.
+                    // Para a listagem de sites, a query base é o que importa.
+                }
+            }
         }
+
         if ($request->filled('is_active_filter') && $request->is_active_filter !== 'all') {
             $query->where('is_active', (bool)$request->is_active_filter);
         }
 
-        $sites = $query->withCount('barriers')->paginate(15)->withQueryString(); // Adiciona contagem de barreiras
-        $companies_for_filter = Company::orderBy('name')->get();
+        $query->orderBy('company_id')->orderBy('name', 'asc'); // Adicionar ordenação aqui
+        $sites = $query->withCount('barriers')->paginate(15)->withQueryString();
 
         $currentCompanyFromController = null;
         // Usamos company_filter porque é o que o filtro da página usa.
@@ -38,9 +88,25 @@ class SiteController extends Controller
         // Ou melhor, vamos verificar os dois, dando prioridade ao filtro explícito.
         $companyIdForBreadcrumb = $request->input('company_filter', $request->input('company_id'));
 
-        if ($companyIdForBreadcrumb) {
-            $currentCompanyFromController = Company::find($companyIdForBreadcrumb);
+        if ($user->isSuperAdmin()) {
+            if ($companyIdForBreadcrumb) {
+                $currentCompanyFromController = Company::find($companyIdForBreadcrumb);
+            }
+        } else if ($user->company_id) {
+            // Para CompanyAdmin/SiteManager, currentCompany é sempre a sua.
+            // O company_filter no request pode ser usado se for igual ao user->company_id, caso contrário, é a empresa do user.
+            if ($companyIdForBreadcrumb && $companyIdForBreadcrumb == $user->company_id) {
+                 $currentCompanyFromController = Company::find($user->company_id);
+            } else {
+                 $currentCompanyFromController = Company::find($user->company_id); // Default para a empresa do user
+            }
+             // Se $companies_for_filter só tem uma empresa, podemos usá-la.
+            if ($companies_for_filter->count() === 1) {
+                $currentCompanyFromController = $companies_for_filter->first();
+            }
+
         }
+
 
         return view('admin.sites.index', compact('sites', 'companies_for_filter', 'currentCompanyFromController'));
     }
@@ -50,7 +116,22 @@ class SiteController extends Controller
      */
     public function create()
     {
+        // Apenas CompanyAdmin (para sua empresa) ou SuperAdmin podem criar sites.
+        // O Gate::before trata SuperAdmin. CompanyAdmin precisa de 'sites:create-own-company'.
+        // A lógica de qual company_id usar no form será tratada na view ou aqui.
+        $this->authorize('sites:create-own-company'); // CompanyAdmin
+                                                    // SuperAdmin passará devido ao Gate::before
+
         $companies = Company::where('is_active', true)->orderBy('name')->pluck('name', 'id');
+        // Para CompanyAdmin, idealmente filtraríamos $companies para mostrar apenas a sua.
+        // Esta lógica será adicionada no Passo 4 (Adaptar Queries/Controladores).
+        if (auth()->user()->hasRole('company-admin') && auth()->user()->company_id) {
+            $companies = Company::where('id', auth()->user()->company_id)
+                                ->where('is_active', true)
+                                ->orderBy('name')
+                                ->pluck('name', 'id');
+        }
+
         return view('admin.sites.create', compact('companies'));
     }
 
@@ -59,6 +140,19 @@ class SiteController extends Controller
      */
     public function store(Request $request)
     {
+        // Autorização: quem pode criar um site.
+        // SuperAdmin pode (Gate::before).
+        // CompanyAdmin pode criar para a sua própria empresa ('sites:create-own-company').
+        $this->authorize('sites:create-own-company');
+
+        // Validação adicional: Se for CompanyAdmin, garantir que o company_id é o seu.
+        if (auth()->user()->hasRole('company-admin')) {
+            if ($request->company_id != auth()->user()->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION. Company Admin can only create sites for their own company.');
+            }
+        }
+        // Para SuperAdmin, company_id pode ser qualquer um válido.
+
         $validatedData = $request->validate([
             'company_id' => 'required|exists:companies,id',
             'name' => [
@@ -83,7 +177,38 @@ class SiteController extends Controller
      */
     public function edit(Site $site)
     {
+        $user = auth()->user();
+        if ($user->isSuperAdmin()) {
+            $this->authorize('sites:update-any');
+        } elseif ($user->hasRole('company-admin')) {
+            if ($site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            $this->authorize('sites:update-own-company');
+        } elseif ($user->hasRole('site-manager')) {
+            // Para SiteManager, precisamos verificar se este $site está entre os seus sites "assigned".
+            // Esta lógica de "assigned sites" não está totalmente definida ainda (requer site_user pivot ou similar).
+            // Assumindo por agora que SiteManager tem acesso a todos os sites da company_id do seu User.
+            // E a permissão 'sites:update-assigned' implica que ele pode atualizar *algum* site que lhe é atribuído.
+            // A verificação de propriedade específica ($user->can('update', $site) com Policy) é melhor.
+            // Por agora, se ele for um site-manager da mesma empresa do site:
+            if ($site->company_id !== $user->company_id) { // Assumindo que site-manager tem company_id
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            $this->authorize('sites:update-assigned');
+        } else {
+            abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
         $companies = Company::where('is_active', true)->orderBy('name')->pluck('name', 'id');
+        if ($user->hasRole('company-admin') && $user->company_id) {
+            $companies = Company::where('id', $user->company_id)
+                                ->where('is_active', true)
+                                ->orderBy('name')
+                                ->pluck('name', 'id');
+        }
+        // Para SiteManager, ele não deve poder mudar a empresa do site. O campo company_id deve ser read-only.
+
         return view('admin.sites.edit', compact('site', 'companies'));
     }
 
@@ -92,8 +217,42 @@ class SiteController extends Controller
      */
     public function update(Request $request, Site $site)
     {
+        $user = auth()->user();
+        if ($user->isSuperAdmin()) {
+            $this->authorize('sites:update-any');
+        } elseif ($user->hasRole('company-admin')) {
+            if ($site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            // CompanyAdmin não deve mudar o company_id de um site para outra empresa.
+            // Se o company_id estiver no request, deve ser o mesmo que o user->company_id.
+            if ($request->input('company_id') && $request->input('company_id') != $user->company_id) {
+                 abort(403, 'Company Admin cannot change the site to a different company.');
+            }
+            $this->authorize('sites:update-own-company');
+        } elseif ($user->hasRole('site-manager')) {
+            if ($site->company_id !== $user->company_id) { // Assumindo site-manager tem company_id e só gere sites dessa company
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            // SiteManager não deve poder mudar o company_id.
+            if ($request->input('company_id') && $request->input('company_id') != $site->company_id) {
+                 abort(403, 'Site Manager cannot change the company of the site.');
+            }
+            $this->authorize('sites:update-assigned');
+        } else {
+            abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
         $validatedData = $request->validate([
-            'company_id' => 'required|exists:companies,id',
+            // Se o user não for SuperAdmin, o company_id não deve ser alterável ou deve ser validado contra a sua própria company.
+            'company_id' => ['required', 'exists:companies,id', function ($attribute, $value, $fail) use ($user, $site) {
+                if ($user->hasRole('company-admin') && $value != $user->company_id) {
+                    $fail('You can only assign sites to your own company.');
+                }
+                if ($user->hasRole('site-manager') && $value != $site->company_id) {
+                    $fail('Site Managers cannot change the company of a site.');
+                }
+            }],
             'name' => [
                 'required',
                 'string',
@@ -116,6 +275,24 @@ class SiteController extends Controller
      */
     public function destroy(Site $site)
     {
+        $user = auth()->user();
+        if ($user->isSuperAdmin()) {
+            $this->authorize('sites:delete-any');
+        } elseif ($user->hasRole('company-admin')) {
+            if ($site->company_id !== $user->company_id) {
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            $this->authorize('sites:delete-own-company');
+        } elseif ($user->hasRole('site-manager')) {
+            if ($site->company_id !== $user->company_id) { // Verificação básica
+                abort(403, 'UNAUTHORIZED ACTION.');
+            }
+            // Adicionar verificação se este site específico está atribuído ao site manager, se a lógica for mais granular.
+            $this->authorize('sites:delete-assigned');
+        } else {
+            abort(403, 'UNAUTHORIZED ACTION.');
+        }
+
         try {
             // onDelete('cascade') na migration de 'barriers' deve cuidar das barreiras associadas.
             $site->delete();

--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Models\Role;
+use App\Models\Company;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules;
+use Illuminate\Support\Facades\Auth; // Para obter o utilizador autenticado
+
+class UserController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $user = Auth::user();
+        $query = User::with('roles', 'company'); // Eager load roles and company
+
+        if ($user->isSuperAdmin()) {
+            $this->authorize('users:view-any');
+            // SuperAdmin vê todos os utilizadores
+        } elseif ($user->hasRole('company-admin') && $user->company_id) {
+            $this->authorize('users:view-own-company');
+            // CompanyAdmin vê utilizadores da sua própria empresa
+            $query->where('company_id', $user->company_id);
+        } else {
+            // Outros papéis não devem aceder a esta listagem geral
+            abort(403, 'THIS ACTION IS UNAUTHORIZED.');
+        }
+
+        // Filtros (opcional, pode ser adicionado depois se necessário)
+        if ($request->filled('name_filter')) {
+            $query->where('name', 'like', '%' . $request->name_filter . '%');
+        }
+        if ($request->filled('email_filter')) {
+            $query->where('email', 'like', '%' . $request->email_filter . '%');
+        }
+        if ($request->filled('role_filter')) {
+            $role_filter_id = $request->role_filter;
+            $query->whereHas('roles', function ($q) use ($role_filter_id) {
+                $q->where('id', $role_filter_id);
+            });
+        }
+
+        $users = $query->orderBy('name')->paginate(15)->withQueryString();
+        $roles_for_filter = Role::orderBy('name')->get(); // Para o dropdown de filtro de papéis
+
+        return view('admin.users.index', compact('users', 'roles_for_filter'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        $user = Auth::user();
+        $editable_roles = [];
+        $companies = collect();
+
+        if ($user->isSuperAdmin()) {
+            $this->authorize('users:create-company-admin'); // Ou uma permissão mais genérica como 'users:create'
+            // SuperAdmin pode criar CompanyAdmins (e outros SuperAdmins se houver perm para isso)
+            // e atribuir-lhes qualquer papel e qualquer empresa.
+            $editable_roles = Role::orderBy('name')->get();
+            $companies = Company::orderBy('name')->get();
+        } elseif ($user->hasRole('company-admin')) {
+            $this->authorize('users:create-site-manager-own-company');
+            // CompanyAdmin só pode criar SiteManagers para a sua própria empresa.
+            $editable_roles = Role::where('name', 'site-manager')->get(); // Apenas o papel 'site-manager'
+            $companies = Company::where('id', $user->company_id)->get(); // Apenas a sua empresa
+        } else {
+            abort(403, 'THIS ACTION IS UNAUTHORIZED.');
+        }
+
+        return view('admin.users.create', compact('editable_roles', 'companies'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $creator = Auth::user();
+
+        $validatedData = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'role_ids' => ['required', 'array'],
+            'role_ids.*' => ['exists:roles,id'],
+            'company_id' => ['nullable', 'exists:companies,id'],
+        ]);
+
+        $target_role_names = Role::whereIn('id', $validatedData['role_ids'])->pluck('name');
+        $new_user_company_id = $validatedData['company_id'] ?? null;
+
+        if ($creator->isSuperAdmin()) {
+            // SuperAdmin pode criar CompanyAdmins (e outros) e atribuir empresa.
+            // Precisa de permissão para criar o tipo de utilizador/papel que está a tentar criar.
+            // Ex: Se está a atribuir 'company-admin', precisa de 'users:create-company-admin'.
+            // Esta lógica pode ser refinada com Gate::inspect ou verificações mais granulares.
+            // Por agora, uma permissão genérica de criar para SuperAdmin é assumida.
+            $this->authorize('users:create-company-admin'); // Exemplo, pode precisar de mais.
+
+            if ($target_role_names->contains('company-admin') && !$new_user_company_id) {
+                 return back()->withInput()->withErrors(['company_id' => 'A Company ID is required for Company Admins.']);
+            }
+
+        } elseif ($creator->hasRole('company-admin')) {
+            $this->authorize('users:create-site-manager-own-company');
+            // CompanyAdmin só pode criar SiteManagers.
+            if (!$target_role_names->contains('site-manager') || $target_role_names->count() > 1) {
+                abort(403, 'Company Admins can only create Site Managers.');
+            }
+            // E o SiteManager deve ser associado à empresa do CompanyAdmin.
+            if ($new_user_company_id != $creator->company_id) {
+                 // Forçar company_id ou dar erro se não for a do criador
+                 $new_user_company_id = $creator->company_id;
+                 // return back()->withInput()->withErrors(['company_id' => 'Site Managers must be assigned to your company.']);
+            }
+        } else {
+            abort(403, 'THIS ACTION IS UNAUTHORIZED.');
+        }
+
+
+        $user = User::create([
+            'name' => $validatedData['name'],
+            'email' => $validatedData['email'],
+            'password' => Hash::make($validatedData['password']),
+            'company_id' => $new_user_company_id,
+            'email_verified_at' => now(), // Opcional: auto-verificar ou enviar email de verificação
+        ]);
+
+        $user->roles()->sync($validatedData['role_ids']);
+
+        return redirect()->route('admin.users.index')->with('success', 'User created successfully.');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(User $managedUser) // Renomeado $user para $managedUser para evitar conflito com Auth::user()
+    {
+        $editor = Auth::user();
+        $editable_roles = collect();
+        $companies = collect();
+
+        // Lógica de autorização para editar $managedUser
+        if ($editor->isSuperAdmin()) {
+            $this->authorize('users:update-any');
+            $editable_roles = Role::orderBy('name')->get();
+            $companies = Company::orderBy('name')->get();
+        } elseif ($editor->hasRole('company-admin') && $editor->company_id === $managedUser->company_id) {
+            // CompanyAdmin pode editar utilizadores da sua própria empresa.
+            // Só pode atribuir/alterar para o papel 'site-manager' (ou remover se for site-manager).
+            $this->authorize('users:update-own-company-user', $managedUser);
+            if (!$managedUser->hasRole('site-manager') && !$managedUser->roles->isEmpty()){ // Se o user já tem um papel que não é site-manager
+                 abort(403, 'Company Admins can only manage Site Managers.');
+            }
+            $editable_roles = Role::where('name', 'site-manager')->get(); // Só pode gerir o papel de site-manager
+            $companies = Company::where('id', $editor->company_id)->get(); // Só a sua empresa
+        } elseif ($editor->id === $managedUser->id) {
+            // Utilizador a editar o seu próprio perfil (lógica diferente, talvez rota /profile)
+            $this->authorize('users:update-own', $managedUser);
+            // Geralmente não se permite mudar o próprio papel ou empresa.
+            $editable_roles = $managedUser->roles; // Mostra os papéis atuais, mas não permite edição por esta via.
+            if($managedUser->company_id) $companies = Company::where('id', $managedUser->company_id)->get();
+
+        } else {
+            abort(403, 'THIS ACTION IS UNAUTHORIZED.');
+        }
+
+        return view('admin.users.edit', compact('managedUser', 'editable_roles', 'companies'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, User $managedUser) // Renomeado $user para $managedUser
+    {
+        $editor = Auth::user();
+
+        // Validação base (nome e email)
+        $validatedData = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,' . $managedUser->id],
+            'password' => ['nullable', 'confirmed', Rules\Password::defaults()], // Password é opcional na atualização
+            'role_ids' => ['sometimes', 'required', 'array'], // 'sometimes' para que não seja obrigatório se não se estiver a mudar papéis
+            'role_ids.*' => ['exists:roles,id'],
+            'company_id' => ['nullable', 'exists:companies,id'],
+        ]);
+
+        $target_role_ids = $request->input('role_ids', $managedUser->roles->pluck('id')->toArray());
+        $target_role_names = Role::whereIn('id', $target_role_ids)->pluck('name');
+        $new_company_id = $request->input('company_id', $managedUser->company_id);
+
+
+        // Lógica de Autorização e Validação de Papel/Empresa
+        if ($editor->isSuperAdmin()) {
+            $this->authorize('users:update-any');
+            if ($target_role_names->contains('company-admin') && !$new_company_id) {
+                 return back()->withInput()->withErrors(['company_id' => 'A Company ID is required for Company Admins.']);
+            }
+            // SuperAdmin pode mudar tudo.
+        } elseif ($editor->hasRole('company-admin') && $editor->company_id === $managedUser->company_id) {
+            $this->authorize('users:update-own-company-user', $managedUser);
+            // CompanyAdmin só pode gerir 'site-manager'
+            if (!$target_role_names->contains('site-manager') || $target_role_names->filter(fn($name) => $name !== 'site-manager')->isNotEmpty()) {
+                 if (!$target_role_names->isEmpty() || ($target_role_names->isEmpty() && $request->has('role_ids'))) { // Permite desatribuir o papel de site-manager
+                    abort(403, 'Company Admins can only assign/unassign the Site Manager role.');
+                 }
+            }
+            // CompanyAdmin não pode mudar a empresa do utilizador
+            if ($new_company_id != $editor->company_id) {
+                abort(403, 'Company Admins cannot change the company of a user.');
+            }
+            $new_company_id = $editor->company_id; // Garantir
+        } elseif ($editor->id === $managedUser->id) {
+            $this->authorize('users:update-own', $managedUser);
+            // Utilizador não pode mudar o seu próprio papel ou empresa através deste form.
+            // Se 'role_ids' ou 'company_id' vierem no request, devem ser ignorados ou validados para não mudar.
+            if ($request->has('role_ids') && array_diff($target_role_ids, $managedUser->roles->pluck('id')->toArray())) {
+                 abort(403, 'You cannot change your own roles.');
+            }
+            if ($request->has('company_id') && $new_company_id != $managedUser->company_id) {
+                 abort(403, 'You cannot change your own company assignment.');
+            }
+            $target_role_ids = $managedUser->roles->pluck('id')->toArray(); // Manter os papéis atuais
+            $new_company_id = $managedUser->company_id; // Manter a empresa atual
+        } else {
+            abort(403, 'THIS ACTION IS UNAUTHORIZED.');
+        }
+
+        // Atualizar dados do utilizador
+        $managedUser->name = $validatedData['name'];
+        $managedUser->email = $validatedData['email'];
+        if (!empty($validatedData['password'])) {
+            $managedUser->password = Hash::make($validatedData['password']);
+        }
+        $managedUser->company_id = $new_company_id; // Atualizar company_id
+        $managedUser->save();
+
+        // Sincronizar papéis (se permitido pela lógica de autorização acima)
+        if ($editor->isSuperAdmin() || ($editor->hasRole('company-admin') && $editor->company_id === $managedUser->company_id)) {
+             if ($request->has('role_ids')) { // Só sincronizar se 'role_ids' foi enviado
+                $managedUser->roles()->sync($target_role_ids);
+             }
+        }
+
+
+        return redirect()->route('admin.users.index')->with('success', 'User updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(User $managedUser) // Renomeado $user para $managedUser
+    {
+        $editor = Auth::user();
+
+        if ($managedUser->id === $editor->id) {
+            abort(403, 'You cannot delete yourself.');
+        }
+
+        if ($editor->isSuperAdmin()) {
+            $this->authorize('users:delete-any');
+            // SuperAdmin pode excluir qualquer um (exceto ele mesmo, talvez)
+        } elseif ($editor->hasRole('company-admin') && $editor->company_id === $managedUser->company_id) {
+            // CompanyAdmin só pode excluir SiteManagers da sua empresa.
+            if (!$managedUser->hasRole('site-manager')) {
+                abort(403, 'Company Admins can only delete Site Managers from their company.');
+            }
+            $this->authorize('users:delete-own-company-user', $managedUser);
+        } else {
+            abort(403, 'THIS ACTION IS UNAUTHORIZED.');
+        }
+
+        // Adicional: Prevenir exclusão do último SuperAdmin? (Lógica mais complexa)
+
+        $managedUser->roles()->detach(); // Remover associações de papéis antes de excluir
+        $managedUser->delete();
+
+        return redirect()->route('admin.users.index')->with('success', 'User deleted successfully.');
+    }
+}

--- a/backend/app/Models/Company.php
+++ b/backend/app/Models/Company.php
@@ -29,6 +29,14 @@ class Company extends Model
     }
 
     /**
+     * Get the users associated with this company (e.g., company admins).
+     */
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+
+    /**
      * Get all of the vehicle permissions for the company.
      */
     public function vehiclePermissions(): \Illuminate\Database\Eloquent\Relations\MorphMany

--- a/backend/app/Models/Permission.php
+++ b/backend/app/Models/Permission.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'display_name',
+        'group_name',
+        'description',
+    ];
+
+    /**
+     * The roles that belong to the permission.
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'permission_role');
+    }
+}

--- a/backend/app/Models/Role.php
+++ b/backend/app/Models/Role.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'display_name',
+        'description',
+    ];
+
+    /**
+     * The users that belong to the role.
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'role_user');
+    }
+
+    /**
+     * The permissions that belong to the role.
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'permission_role');
+    }
+
+    /**
+     * Grant the given permission to a role.
+     *
+     * @param Permission $permission
+     * @return void
+     */
+    public function grantPermissionTo(Permission $permission)
+    {
+        $this->permissions()->syncWithoutDetaching($permission);
+    }
+
+    /**
+     * Revoke the given permission from a role.
+     *
+     * @param Permission $permission
+     * @return void
+     */
+    public function revokePermissionTo(Permission $permission)
+    {
+        $this->permissions()->detach($permission);
+    }
+
+    /**
+     * Check if the role has a specific permission.
+     *
+     * @param string|Permission $permission Name of the permission or Permission object
+     * @return bool
+     */
+    public function hasPermissionTo($permission): bool
+    {
+        if (is_string($permission)) {
+            return $this->permissions->contains('name', $permission);
+        }
+
+        if ($permission instanceof Permission) {
+            return $this->permissions->contains('id', $permission->id);
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -7,10 +7,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens; // Importar HasApiTokens
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable; // Adicionar HasApiTokens aqui
+
+    // company_id will be added via migration and should be in fillable if managed through User model directly
 
     /**
      * The attributes that are mass assignable.
@@ -21,6 +25,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'company_id', // Make company_id fillable
     ];
 
     /**
@@ -42,4 +47,99 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    /**
+     * Get the company that the user might belong to (e.g., for a CompanyAdmin).
+     */
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    /**
+     * The roles that belong to the user.
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_user');
+    }
+
+    /**
+     * Assign a role to the user.
+     *
+     * @param string|Role $role
+     * @return void
+     */
+    public function assignRole($role)
+    {
+        if (is_string($role)) {
+            $role = Role::where('name', $role)->firstOrFail();
+        }
+        $this->roles()->syncWithoutDetaching($role);
+    }
+
+    /**
+     * Remove a role from the user.
+     *
+     * @param string|Role $role
+     * @return void
+     */
+    public function removeRole($role)
+    {
+        if (is_string($role)) {
+            $role = Role::where('name', $role)->firstOrFail();
+        }
+        $this->roles()->detach($role);
+    }
+
+    /**
+     * Check if the user has a specific role.
+     *
+     * @param string|array $role Name of the role, or array of role names.
+     * @return bool
+     */
+    public function hasRole($role): bool
+    {
+        if (is_array($role)) {
+            return $this->roles->pluck('name')->intersect($role)->isNotEmpty();
+        }
+        return $this->roles->contains('name', $role);
+    }
+
+    /**
+     * Check if the user has a specific permission, directly or through a role.
+     * This method iterates through user's roles and checks if any role has the permission.
+     *
+     * @param string|Permission $permission Name of the permission or Permission object.
+     * @return bool
+     */
+    public function hasPermissionTo($permission): bool
+    {
+        $permissionName = is_string($permission) ? $permission : ($permission instanceof Permission ? $permission->name : null);
+
+        if (!$permissionName) {
+            return false; // Or throw an exception for invalid argument
+        }
+
+        // Eager load roles and their permissions if not already loaded, to optimize.
+        // However, direct check is often fine for a single user instance.
+        // $this->loadMissing('roles.permissions');
+
+
+        foreach ($this->roles as $role) {
+            if ($role->hasPermissionTo($permissionName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if the user is a super-admin.
+     * Assumes 'super-admin' is the name of the role.
+     */
+    public function isSuperAdmin(): bool
+    {
+        return $this->hasRole('super-admin');
+    }
 }

--- a/backend/app/Providers/AuthServiceProvider.php
+++ b/backend/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Providers;
+
+// use Illuminate\Support\Facades\Gate; // Será descomentado e usado
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate; // Adicionado para uso
+use App\Models\User;
+use App\Models\Permission; // Precisaremos disto para iterar sobre as permissões
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The model to policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        // 'App\Models\Model' => 'App\Policies\ModelPolicy', // Exemplo padrão
+    ];
+
+    /**
+     * Register any authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        $this->registerPolicies();
+
+        // Gate para Super Admin - concede todas as permissões
+        Gate::before(function (User $user, $ability) {
+            if ($user->isSuperAdmin()) {
+                return true;
+            }
+            return null; // Deixa outros gates decidirem
+        });
+
+        // Registrar Gates dinamicamente a partir das permissões na BD
+        // É importante que as permissões já estejam na BD (via seeder) para isto funcionar na inicialização.
+        // Envolver em try-catch para evitar erros durante migrations/setup inicial antes da BD estar pronta.
+        try {
+            // Verifica se a tabela permissions existe para evitar erros durante as migrations iniciais
+            if (\Illuminate\Support\Facades\Schema::hasTable('permissions')) {
+                Permission::all()->each(function (Permission $permission) {
+                    Gate::define($permission->name, function (User $user) use ($permission) {
+                        return $user->hasPermissionTo($permission->name);
+                    });
+                });
+            }
+        } catch (\Exception $e) {
+            // Logar o erro ou lidar com ele de forma apropriada se ocorrer durante o boot
+            // Pode ser que a BD não esteja acessível durante o artisan config:cache ou similar
+            \Illuminate\Support\Facades\Log::error('AuthServiceProvider: Could not register dynamic gates: ' . $e->getMessage());
+        }
+
+        // NOTA: Se houver permissões que necessitem de lógica mais complexa
+        // (ex: verificar se o utilizador é dono do recurso - companies:update-own),
+        // elas podem precisar de Gates definidos explicitamente aqui ou através de Policies.
+        // Por exemplo, para 'companies:update-own':
+        // Gate::define('companies:update-own', function (User $user, \App\Models\Company $company) {
+        //     // Primeiro, o utilizador tem a permissão genérica 'companies:update-own'?
+        //     if (!$user->hasPermissionTo('companies:update-own')) {
+        //         return false;
+        //     }
+        //     // Se sim, ele é o dono desta empresa específica? (se for um company-admin)
+        //     if ($user->hasRole('company-admin')) {
+        //         return $user->company_id === $company->id;
+        //     }
+        //     // Se não for company-admin mas tiver a permissão (ex: super-admin já tratado pelo Gate::before), permite.
+        //     // Ou se a lógica for que SÓ company-admin pode ter 'companies:update-own', então o hasPermissionTo já filtraria.
+        //     // A lógica exata aqui depende de como as permissões são atribuídas.
+        //     // O Gate::before para super-admin já cobre o acesso total.
+        //     // Para company-admin, o hasPermissionTo('companies:update-own') será verificado,
+        //     // e a lógica de propriedade será adicionalmente verificada no controlador ou policy.
+        //     // Por agora, o Gate dinâmico acima é suficiente para a verificação base da permissão.
+        //     // A lógica de propriedade será melhor tratada em Policies ou diretamente nos controladores após a autorização base.
+        //     return true; // Este Gate específico pode não ser necessário se a Policy tratar disso.
+        // });
+    }
+}

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,10 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\Role;
+use Illuminate\Support\Facades\Hash; // Import Hash
 
 class DatabaseSeeder extends Seeder
 {
@@ -12,12 +14,46 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
+        // Call the RBAC seeders first
+        $this->call([
+            RolesTableSeeder::class,
+            PermissionsTableSeeder::class,
+            PermissionRoleTableSeeder::class,
+        ]);
 
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
+        // Create a Super Admin User
+        $superAdminRole = Role::where('name', 'super-admin')->first();
+
+        if ($superAdminRole) {
+            $superAdminUser = User::firstOrCreate(
+                ['email' => 'superadmin@example.com'],
+                [
+                    'name' => 'Super Admin',
+                    'password' => Hash::make('password'), // Use a secure password, this is just an example
+                    'email_verified_at' => now(),
+                ]
+            );
+            $superAdminUser->assignRole($superAdminRole); // AssignRole method is in User model
+
+            $this->command->info('Super Admin user created and role assigned.');
+
+            // You can create other default users here if needed
+            // e.g., a Company Admin for a test company
+
+        } else {
+            $this->command->error('Super Admin role not found. Cannot create Super Admin user.');
+        }
+
+
+        // Example: Create some companies, sites, and barriers if needed for testing
+        // Ensure these seeders are created and called if you uncomment them.
+        // $this->call([
+        //     CompanySeeder::class, // You would need to create this seeder
+        //     SiteSeeder::class,    // You would need to create this seeder
+        //     BarrierSeeder::class, // You would need to create this seeder
         // ]);
+
+        // \App\Models\User::factory(10)->create(); // Default user factory
 
         $this->call([
             // Primeiro os veículos, pois as permissões dependem deles

--- a/backend/resources/views/admin/users/_form.blade.php
+++ b/backend/resources/views/admin/users/_form.blade.php
@@ -1,0 +1,151 @@
+@csrf
+<div class="row">
+    <div class="col-md-6">
+        <div class="form-group">
+            <label for="name">Name <span class="text-danger">*</span></label>
+            <input type="text" name="name" id="name" class="form-control @error('name') is-invalid @enderror"
+                   value="{{ old('name', $managedUser->name ?? '') }}" required>
+            @error('name')
+                <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
+            @enderror
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="form-group">
+            <label for="email">Email <span class="text-danger">*</span></label>
+            <input type="email" name="email" id="email" class="form-control @error('email') is-invalid @enderror"
+                   value="{{ old('email', $managedUser->email ?? '') }}" required>
+            @error('email')
+                <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
+            @enderror
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="form-group">
+            <label for="password">Password @if(!isset($managedUser))<span class="text-danger">*</span>@endif</label>
+            <input type="password" name="password" id="password" class="form-control @error('password') is-invalid @enderror"
+                   @if(!isset($managedUser)) required @endif>
+            @if(isset($managedUser))<small class="form-text text-muted">Leave blank to keep current password.</small>@endif
+            @error('password')
+                <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
+            @enderror
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="form-group">
+            <label for="password_confirmation">Confirm Password @if(!isset($managedUser))<span class="text-danger">*</span>@endif</label>
+            <input type="password" name="password_confirmation" id="password_confirmation" class="form-control"
+                   @if(!isset($managedUser)) required @endif>
+        </div>
+    </div>
+</div>
+
+@php
+    $currentUser = Auth::user();
+    $isEditingSelf = isset($managedUser) && $currentUser->id === $managedUser->id;
+    $canManageRoles = false; // Se pode mudar os papéis do $managedUser
+    $canManageCompany = false; // Se pode mudar a empresa do $managedUser
+
+    if ($currentUser->isSuperAdmin()) {
+        $canManageRoles = true;
+        $canManageCompany = true;
+    } elseif ($currentUser->hasRole('company-admin')) {
+        // CompanyAdmin pode gerir papéis de SiteManagers da sua empresa.
+        // Não pode mudar a empresa de ninguém.
+        if (isset($managedUser) && $currentUser->company_id === $managedUser->company_id) {
+            $canManageRoles = true; // Limitado a 'site-manager' no controlador.
+        } elseif (!isset($managedUser)) { // Ao criar novo user
+            $canManageRoles = true; // Limitado a 'site-manager' no controlador.
+        }
+        $canManageCompany = false; // CompanyAdmin não muda a empresa de outros, é fixada à sua.
+                                 // E ao criar, a empresa é a sua.
+    }
+    // Utilizador a editar o seu próprio perfil não pode mudar papel ou empresa através deste form.
+    if ($isEditingSelf) {
+        $canManageRoles = false;
+        $canManageCompany = false;
+    }
+
+@endphp
+
+
+@if($canManageRoles && $editable_roles->count() > 0)
+<div class="form-group">
+    <label for="role_ids">Roles <span class="text-danger">*</span></label>
+    <select name="role_ids[]" id="role_ids" class="form-control select2 @error('role_ids') is-invalid @enderror" multiple required>
+        @foreach($editable_roles as $role)
+            <option value="{{ $role->id }}"
+                @if(isset($managedUser) && $managedUser->roles->contains($role->id)) selected @endif
+                @if(is_array(old('role_ids')) && in_array($role->id, old('role_ids'))) selected @endif>
+                {{ $role->display_name ?? $role->name }}
+            </option>
+        @endforeach
+    </select>
+    @error('role_ids')
+        <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
+    @enderror
+    @if($currentUser->hasRole('company-admin') && !$currentUser->isSuperAdmin())
+        <small class="form-text text-muted">Company Admins can only assign the 'Site Manager' role.</small>
+    @endif
+</div>
+@elseif(isset($managedUser) && !$canManageRoles && $managedUser->roles->count() > 0)
+    <div class="form-group">
+        <label>Roles</label>
+        <p>
+            @foreach($managedUser->roles as $role)
+                <span class="badge badge-info">{{ $role->display_name ?? $role->name }}</span>
+            @endforeach
+        </p>
+        <small class="form-text text-muted">Your roles cannot be changed through this form.</small>
+    </div>
+@endif
+
+
+@if($canManageCompany && $companies->count() > 0)
+    <div class="form-group">
+        <label for="company_id">Company</label>
+        <select name="company_id" id="company_id" class="form-control @error('company_id') is-invalid @enderror">
+            <option value="">Assign to Company (Optional)</option>
+            @foreach($companies as $company)
+                <option value="{{ $company->id }}"
+                    @if( (isset($managedUser) && $managedUser->company_id == $company->id) || old('company_id') == $company->id) selected @endif >
+                    {{ $company->name }}
+                </option>
+            @endforeach
+        </select>
+        @error('company_id')
+            <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
+        @enderror
+        <small class="form-text text-muted">Required if assigning 'Company Admin' role.</small>
+    </div>
+@elseif(isset($managedUser) && $managedUser->company_id && !$canManageCompany)
+    <div class="form-group">
+        <label>Company</label>
+        <p>{{ $managedUser->company->name ?? 'N/A' }}</p>
+        @if($currentUser->hasRole('company-admin') && $currentUser->company_id === $managedUser->company_id)
+             <small class="form-text text-muted">Users created by Company Admins are automatically assigned to your company.</small>
+        @else
+            <small class="form-text text-muted">Your company assignment cannot be changed through this form.</small>
+        @endif
+    </div>
+@elseif(!isset($managedUser) && $currentUser->hasRole('company-admin') && $currentUser->company_id)
+    {{-- Ao criar novo user, se o criador é CompanyAdmin, a empresa é fixada e mostrada --}}
+    <div class="form-group">
+        <label>Company</label>
+        @php $creatorCompany = $companies->first(); @endphp
+        <p>{{ $creatorCompany->name ?? 'Error: Company not found for creator' }}</p>
+        <input type="hidden" name="company_id" value="{{ $creatorCompany->id ?? '' }}">
+        <small class="form-text text-muted">This user will be assigned to your company: {{ $creatorCompany->name ?? '' }}.</small>
+    </div>
+@endif
+
+
+<div class="form-group mt-4">
+    <button type="submit" class="btn btn-primary">
+        {{ isset($managedUser) ? 'Update User' : 'Create User' }}
+    </button>
+    <a href="{{ route('admin.users.index') }}" class="btn btn-secondary">Cancel</a>
+</div>

--- a/backend/resources/views/admin/users/create.blade.php
+++ b/backend/resources/views/admin/users/create.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.admin_app')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <h2>Add New User</h2>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            User Details
+        </div>
+        <div class="card-body">
+            @include('partials.admin.error_messages') {{-- Para mostrar erros de validação --}}
+
+            <form method="POST" action="{{ route('admin.users.store') }}">
+                @include('admin.users._form', ['managedUser' => null, 'editable_roles' => $editable_roles, 'companies' => $companies])
+            </form>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+    {{-- Inicializar select2 se estiver a ser usado --}}
+    <script>
+        $(document).ready(function() {
+            $('.select2').select2({
+                placeholder: "Select roles",
+                allowClear: true
+            });
+        });
+    </script>
+@endpush

--- a/backend/resources/views/admin/users/index.blade.php
+++ b/backend/resources/views/admin/users/index.blade.php
@@ -1,0 +1,148 @@
+@extends('layouts.admin_app') {{-- Assume que tem um layout base admin --}}
+
+@section('content')
+<div class="container-fluid">
+    <div class="row mb-3">
+        <div class="col-md-12">
+            <h2>User Management</h2>
+        </div>
+    </div>
+
+    @include('partials.admin.operation_messages')
+
+    <div class="card">
+        <div class="card-header">
+            <div class="row">
+                <div class="col-md-6">
+                    Users List
+                </div>
+                <div class="col-md-6 text-right">
+                    @can('users:create-company-admin') {{-- Ou uma permissão mais genérica de criar user que o SuperAdmin tenha --}}
+                        <a href="{{ route('admin.users.create') }}" class="btn btn-primary btn-sm">
+                            <i class="fas fa-plus"></i> Add New User
+                        </a>
+                    @elsecan('users:create-site-manager-own-company') {{-- CompanyAdmin pode criar SiteManagers --}}
+                        <a href="{{ route('admin.users.create') }}" class="btn btn-primary btn-sm">
+                            <i class="fas fa-plus"></i> Add New Site Manager
+                        </a>
+                    @endcan
+                </div>
+            </div>
+        </div>
+        <div class="card-body">
+            {{-- Filtros --}}
+            <form method="GET" action="{{ route('admin.users.index') }}" class="mb-3">
+                <div class="form-row">
+                    <div class="col-md-3">
+                        <input type="text" name="name_filter" class="form-control form-control-sm" placeholder="Filter by Name" value="{{ request('name_filter') }}">
+                    </div>
+                    <div class="col-md-3">
+                        <input type="text" name="email_filter" class="form-control form-control-sm" placeholder="Filter by Email" value="{{ request('email_filter') }}">
+                    </div>
+                    @if(Auth::user()->isSuperAdmin()) {{-- Só SuperAdmin pode filtrar por papel arbitrário por agora --}}
+                    <div class="col-md-3">
+                        <select name="role_filter" class="form-control form-control-sm">
+                            <option value="">All Roles</option>
+                            @foreach($roles_for_filter as $role)
+                                <option value="{{ $role->id }}" {{ request('role_filter') == $role->id ? 'selected' : '' }}>
+                                    {{ $role->display_name ?? $role->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                    @endif
+                    <div class="col-md-1">
+                        <button type="submit" class="btn btn-secondary btn-sm">Filter</button>
+                    </div>
+                    <div class="col-md-1">
+                        <a href="{{ route('admin.users.index') }}" class="btn btn-light btn-sm">Clear</a>
+                    </div>
+                </div>
+            </form>
+
+            <table class="table table-sm table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Name</th>
+                        <th>Email</th>
+                        <th>Roles</th>
+                        <th>Company</th>
+                        <th>Verified</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse ($users as $managedUser) {{-- Renomeado para evitar conflito com Auth::user() --}}
+                        <tr>
+                            <td>{{ $managedUser->id }}</td>
+                            <td>{{ $managedUser->name }}</td>
+                            <td>{{ $managedUser->email }}</td>
+                            <td>
+                                @foreach($managedUser->roles as $role)
+                                    <span class="badge badge-info">{{ $role->display_name ?? $role->name }}</span>
+                                @endforeach
+                            </td>
+                            <td>{{ $managedUser->company->name ?? 'N/A' }}</td>
+                            <td>
+                                @if($managedUser->email_verified_at)
+                                    <span class="badge badge-success">Yes</span>
+                                @else
+                                    <span class="badge badge-warning">No</span>
+                                @endif
+                            </td>
+                            <td>
+                                @php $canUpdate = false; @endphp
+                                @if(Auth::user()->isSuperAdmin())
+                                    @can('users:update-any') @php $canUpdate = true; @endphp @endcan
+                                @elseif(Auth::user()->hasRole('company-admin') && Auth::user()->company_id === $managedUser->company_id)
+                                    @can('users:update-own-company-user', $managedUser) @php $canUpdate = true; @endphp @endcan
+                                @elseif(Auth::id() === $managedUser->id) {{-- Editar o próprio perfil --}}
+                                     @can('users:update-own', $managedUser) @php $canUpdate = true; @endphp @endcan
+                                @endif
+
+                                @if($canUpdate)
+                                <a href="{{ route('admin.users.edit', $managedUser->id) }}" class="btn btn-xs btn-warning">
+                                    <i class="fas fa-edit"></i> Edit
+                                </a>
+                                @endif
+
+                                @if(Auth::id() !== $managedUser->id) {{-- Não pode excluir a si mesmo --}}
+                                    @php $canDelete = false; @endphp
+                                    @if(Auth::user()->isSuperAdmin())
+                                        @can('users:delete-any') @php $canDelete = true; @endphp @endcan
+                                    @elseif(Auth::user()->hasRole('company-admin') && Auth::user()->company_id === $managedUser->company_id)
+                                        @can('users:delete-own-company-user', $managedUser)
+                                            @if($managedUser->hasRole('site-manager')) {{-- CompanyAdmin só pode excluir SiteManagers --}}
+                                                @php $canDelete = true; @endphp
+                                            @endif
+                                        @endcan
+                                    @endif
+
+                                    @if($canDelete)
+                                    <form action="{{ route('admin.users.destroy', $managedUser->id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this user?');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-xs btn-danger">
+                                            <i class="fas fa-trash"></i> Delete
+                                        </button>
+                                    </form>
+                                    @endif
+                                @endif
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7" class="text-center">No users found.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+
+            <div class="mt-3">
+                {{ $users->links() }}
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -55,4 +55,7 @@ Route::prefix('admin')->middleware('auth')->group(function () { // TODO: Impleme
 
     // Barrier Management Routes
     Route::resource('barriers', App\Http\Controllers\BarrierController::class, ['as' => 'admin'])->except(['show']);
+
+    // User Management Routes
+    Route::resource('users', App\Http\Controllers\UserController::class, ['as' => 'admin'])->except(['show']);
 });

--- a/database/migrations/2024_07_30_000001_add_company_id_to_users_table.php
+++ b/database/migrations/2024_07_30_000001_add_company_id_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('company_id')->nullable()->constrained('companies')->onDelete('set null');
+            // onDelete('set null') means if a company is deleted, the company_id for the user becomes null.
+            // Alternatively, onDelete('restrict') would prevent company deletion if users are assigned.
+            // Consider the desired behavior. For now, 'set null' allows company deletion.
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Drop foreign key first if it was explicitly named, otherwise Laravel handles it by convention.
+            // For safety, let's assume it might need explicit dropping if column name differs from table name.
+            // $table->dropForeign(['company_id']); // Or $table->dropForeign('users_company_id_foreign');
+            $table->dropConstrainedForeignId('company_id'); // Simpler way if convention is followed
+        });
+    }
+};

--- a/database/migrations/2024_07_30_000002_create_roles_table.php
+++ b/database/migrations/2024_07_30_000002_create_roles_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique(); // e.g., 'super-admin', 'company-admin'
+            $table->string('display_name')->nullable(); // e.g., 'Super Administrator', 'Company Administrator'
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/database/migrations/2024_07_30_000003_create_permissions_table.php
+++ b/database/migrations/2024_07_30_000003_create_permissions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique(); // e.g., 'companies:create', 'sites:view-own-company'
+            $table->string('display_name')->nullable(); // e.g., 'Create Companies', 'View Own Company Sites'
+            $table->string('group_name')->nullable(); // e.g., 'companies', 'sites', 'users' for grouping in UI
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/database/migrations/2024_07_30_000004_create_role_user_table.php
+++ b/database/migrations/2024_07_30_000004_create_role_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->primary(['role_id', 'user_id']); // Composite primary key
+
+            $table->foreignId('role_id')->constrained('roles')->onDelete('cascade');
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+
+            // No timestamps needed for a simple pivot unless you want to track when a role was assigned/revoked.
+            // $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('role_user');
+    }
+};

--- a/database/migrations/2024_07_30_000005_create_permission_role_table.php
+++ b/database/migrations/2024_07_30_000005_create_permission_role_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('permission_role', function (Blueprint $table) {
+            $table->primary(['permission_id', 'role_id']); // Composite primary key
+
+            $table->foreignId('permission_id')->constrained('permissions')->onDelete('cascade');
+            $table->foreignId('role_id')->constrained('roles')->onDelete('cascade');
+
+            // No timestamps needed here either.
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('permission_role');
+    }
+};

--- a/database/seeders/PermissionRoleTableSeeder.php
+++ b/database/seeders/PermissionRoleTableSeeder.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Role;
+use App\Models\Permission;
+use Illuminate\Support\Facades\DB;
+
+class PermissionRoleTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Detach all existing permissions from roles to start clean,
+        // especially if this seeder is run multiple times.
+        // DB::table('permission_role')->truncate(); // Simplest way if no other logic needed on detach/attach
+
+        $superAdminRole = Role::where('name', 'super-admin')->first();
+        $companyAdminRole = Role::where('name', 'company-admin')->first();
+        $siteManagerRole = Role::where('name', 'site-manager')->first();
+
+        if (!$superAdminRole) {
+            $this->command->error("Role 'super-admin' not found. Please run RolesTableSeeder first.");
+            return;
+        }
+        if (!$companyAdminRole) {
+            $this->command->error("Role 'company-admin' not found. Please run RolesTableSeeder first.");
+            return;
+        }
+        if (!$siteManagerRole) {
+            $this->command->error("Role 'site-manager' not found. Please run RolesTableSeeder first.");
+            return;
+        }
+
+        // --- Super Admin Permissions ---
+        // Super admin gets all permissions
+        $allPermissions = Permission::all();
+        $superAdminRole->permissions()->sync($allPermissions->pluck('id'));
+        $this->command->info("Super Admin permissions synced.");
+
+        // --- Company Admin Permissions ---
+        $companyAdminPermissions = [
+            // Companies
+            'companies:view-own', 'companies:update-own',
+            // Sites
+            'sites:view-own-company', 'sites:create-own-company', 'sites:update-own-company', 'sites:delete-own-company',
+            // Barriers
+            'barriers:view-own-company', 'barriers:create-own-company-site', 'barriers:update-own-company-site', 'barriers:delete-own-company-site',
+            // Vehicles (assuming per-company model for these actions)
+            'vehicles:view-own-company', 'vehicles:create-own-company', 'vehicles:update-own-company', 'vehicles:delete-own-company',
+            // Vehicle Permissions
+            'vehicle-permissions:assign-to-own-company', 'vehicle-permissions:view-own-company',
+            // Users
+            'users:view-own-company', 'users:create-site-manager-own-company',
+            'users:update-own', // All users can update their own profile
+            'users:update-own-company-user', 'users:delete-own-company-user', 'users:assign-roles-own-company', // Assign SiteManager
+            // Access Logs
+            'access-logs:view-own-company',
+            // Firmwares
+            'firmwares:view',
+        ];
+        $companyAdminPermIds = Permission::whereIn('name', $companyAdminPermissions)->pluck('id');
+        $companyAdminRole->permissions()->sync($companyAdminPermIds);
+        $this->command->info("Company Admin permissions synced.");
+
+        // --- Site Manager Permissions ---
+        $siteManagerPermissions = [
+            // Sites
+            'sites:view-assigned', 'sites:update-assigned', // Note: 'update-assigned' should be limited in policy/controller
+            // Barriers
+            'barriers:view-assigned-site', 'barriers:create-assigned-site', 'barriers:update-assigned-site', 'barriers:delete-assigned-site',
+            // Vehicle Permissions
+            'vehicle-permissions:assign-to-assigned-site', 'vehicle-permissions:view-assigned-site',
+            // Users
+            'users:update-own', // All users can update their own profile
+            // Access Logs
+            'access-logs:view-assigned-site',
+            // Firmwares (View only is fine)
+            'firmwares:view',
+        ];
+        $siteManagerPermIds = Permission::whereIn('name', $siteManagerPermissions)->pluck('id');
+        $siteManagerRole->permissions()->sync($siteManagerPermIds);
+        $this->command->info("Site Manager permissions synced.");
+
+        // If you had a 'base-user' role, assign its permissions here
+        // $baseUserRole = Role::where('name', 'base-user')->first();
+        // if ($baseUserRole) {
+        //     $baseUserPermissions = ['users:update-own'];
+        //     $baseUserPermIds = Permission::whereIn('name', $baseUserPermissions)->pluck('id');
+        //     $baseUserRole->permissions()->sync($baseUserPermIds);
+        //     $this->command->info("Base User permissions synced.");
+        // }
+    }
+}

--- a/database/seeders/PermissionsTableSeeder.php
+++ b/database/seeders/PermissionsTableSeeder.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Permission;
+use Illuminate\Support\Facades\DB;
+
+class PermissionsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Permission::truncate(); // Careful with truncate
+
+        $permissions = [
+            // Companies
+            ['name' => 'companies:view-any', 'display_name' => 'View Any Company', 'group_name' => 'Companies'],
+            ['name' => 'companies:view-own', 'display_name' => 'View Own Company', 'group_name' => 'Companies'],
+            ['name' => 'companies:create', 'display_name' => 'Create Company', 'group_name' => 'Companies'],
+            ['name' => 'companies:update-any', 'display_name' => 'Update Any Company', 'group_name' => 'Companies'],
+            ['name' => 'companies:update-own', 'display_name' => 'Update Own Company', 'group_name' => 'Companies'],
+            ['name' => 'companies:delete-any', 'display_name' => 'Delete Any Company', 'group_name' => 'Companies'],
+            // ['name' => 'companies:delete-own', 'display_name' => 'Delete Own Company', 'group_name' => 'Companies'], // Decidimos não dar esta por agora
+
+            // Sites
+            ['name' => 'sites:view-any', 'display_name' => 'View Any Site', 'group_name' => 'Sites'],
+            ['name' => 'sites:view-own-company', 'display_name' => 'View Own Company Sites', 'group_name' => 'Sites'],
+            ['name' => 'sites:view-assigned', 'display_name' => 'View Assigned Sites', 'group_name' => 'Sites'],
+            ['name' => 'sites:create-own-company', 'display_name' => 'Create Site for Own Company', 'group_name' => 'Sites'],
+            ['name' => 'sites:update-any', 'display_name' => 'Update Any Site', 'group_name' => 'Sites'],
+            ['name' => 'sites:update-own-company', 'display_name' => 'Update Own Company Site', 'group_name' => 'Sites'],
+            ['name' => 'sites:update-assigned', 'display_name' => 'Update Assigned Site', 'group_name' => 'Sites'],
+            ['name' => 'sites:delete-any', 'display_name' => 'Delete Any Site', 'group_name' => 'Sites'],
+            ['name' => 'sites:delete-own-company', 'display_name' => 'Delete Own Company Site', 'group_name' => 'Sites'],
+            ['name' => 'sites:delete-assigned', 'display_name' => 'Delete Assigned Site', 'group_name' => 'Sites'],
+
+            // Barriers
+            ['name' => 'barriers:view-any', 'display_name' => 'View Any Barrier', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:view-own-company', 'display_name' => 'View Own Company Barriers', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:view-assigned-site', 'display_name' => 'View Assigned Site Barriers', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:create-own-company-site', 'display_name' => 'Create Barrier for Own Company Site', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:create-assigned-site', 'display_name' => 'Create Barrier for Assigned Site', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:update-any', 'display_name' => 'Update Any Barrier', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:update-own-company-site', 'display_name' => 'Update Own Company Barrier', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:update-assigned-site', 'display_name' => 'Update Assigned Site Barrier', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:delete-any', 'display_name' => 'Delete Any Barrier', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:delete-own-company-site', 'display_name' => 'Delete Own Company Barrier', 'group_name' => 'Barriers'],
+            ['name' => 'barriers:delete-assigned-site', 'display_name' => 'Delete Assigned Site Barrier', 'group_name' => 'Barriers'],
+
+            // Vehicles (Registration - assuming vehicles are global or managed by super-admin mainly for registration)
+            // If vehicles are per-company, these need adjustment. Our current Vehicle model is global.
+            ['name' => 'vehicles:view-any', 'display_name' => 'View Any Vehicle', 'group_name' => 'Vehicles'],
+            ['name' => 'vehicles:create-any', 'display_name' => 'Create Any Vehicle', 'group_name' => 'Vehicles'],
+            ['name' => 'vehicles:update-any', 'display_name' => 'Update Any Vehicle', 'group_name' => 'Vehicles'],
+            ['name' => 'vehicles:delete-any', 'display_name' => 'Delete Any Vehicle', 'group_name' => 'Vehicles'],
+            // Company specific vehicle management if needed:
+            ['name' => 'vehicles:view-own-company', 'display_name' => 'View Own Company Vehicles', 'group_name' => 'Vehicles'],
+            ['name' => 'vehicles:create-own-company', 'display_name' => 'Create Vehicle for Own Company', 'group_name' => 'Vehicles'],
+            ['name' => 'vehicles:update-own-company', 'display_name' => 'Update Own Company Vehicle', 'group_name' => 'Vehicles'],
+            ['name' => 'vehicles:delete-own-company', 'display_name' => 'Delete Own Company Vehicle', 'group_name' => 'Vehicles'],
+
+
+            // Vehicle Permissions (Assigning access)
+            ['name' => 'vehicle-permissions:assign-to-any-company', 'display_name' => 'Assign Vehicle to Any Company', 'group_name' => 'Vehicle Permissions'],
+            ['name' => 'vehicle-permissions:assign-to-own-company', 'display_name' => 'Assign Vehicle to Own Company/Sites/Barriers', 'group_name' => 'Vehicle Permissions'],
+            ['name' => 'vehicle-permissions:assign-to-assigned-site', 'display_name' => 'Assign Vehicle to Assigned Site/Barriers', 'group_name' => 'Vehicle Permissions'],
+            ['name' => 'vehicle-permissions:view-any', 'display_name' => 'View Any Vehicle Permissions', 'group_name' => 'Vehicle Permissions'],
+            ['name' => 'vehicle-permissions:view-own-company', 'display_name' => 'View Own Company Vehicle Permissions', 'group_name' => 'Vehicle Permissions'],
+            ['name' => 'vehicle-permissions:view-assigned-site', 'display_name' => 'View Assigned Site Vehicle Permissions', 'group_name' => 'Vehicle Permissions'],
+
+            // Users
+            ['name' => 'users:view-any', 'display_name' => 'View Any User', 'group_name' => 'Users'],
+            ['name' => 'users:view-own-company', 'display_name' => 'View Own Company Users', 'group_name' => 'Users'],
+            ['name' => 'users:create-super-admin', 'display_name' => 'Create Super Admin', 'group_name' => 'Users'],
+            ['name' => 'users:create-company-admin', 'display_name' => 'Create Company Admin', 'group_name' => 'Users'],
+            ['name' => 'users:create-site-manager-own-company', 'display_name' => 'Create Site Manager for Own Company', 'group_name' => 'Users'],
+            ['name' => 'users:update-any', 'display_name' => 'Update Any User Profile', 'group_name' => 'Users'],
+            ['name' => 'users:update-own', 'display_name' => 'Update Own Profile', 'group_name' => 'Users'], // For all users
+            ['name' => 'users:update-own-company-user', 'display_name' => 'Update Own Company User', 'group_name' => 'Users'],
+            ['name' => 'users:delete-any', 'display_name' => 'Delete Any User', 'group_name' => 'Users'],
+            ['name' => 'users:delete-own-company-user', 'display_name' => 'Delete Own Company User', 'group_name' => 'Users'],
+            ['name' => 'users:assign-roles-any', 'display_name' => 'Assign Roles to Any User', 'group_name' => 'Users'],
+            ['name' => 'users:assign-roles-own-company', 'display_name' => 'Assign SiteManager Role to Own Company User', 'group_name' => 'Users'],
+
+            // Access Logs
+            ['name' => 'access-logs:view-any', 'display_name' => 'View Any Access Logs', 'group_name' => 'Access Logs'],
+            ['name' => 'access-logs:view-own-company', 'display_name' => 'View Own Company Access Logs', 'group_name' => 'Access Logs'],
+            ['name' => 'access-logs:view-assigned-site', 'display_name' => 'View Assigned Site Access Logs', 'group_name' => 'Access Logs'],
+
+            // Firmwares
+            ['name' => 'firmwares:manage', 'display_name' => 'Manage Firmwares', 'group_name' => 'Firmwares'],
+            ['name' => 'firmwares:view', 'display_name' => 'View Firmwares', 'group_name' => 'Firmwares'],
+
+            // API Tokens
+            ['name' => 'api-tokens:manage', 'display_name' => 'Manage API Tokens', 'group_name' => 'API Tokens'],
+
+            // RBAC Management (for SuperAdmin to manage roles/permissions themselves if UI is built)
+            ['name' => 'roles:manage', 'display_name' => 'Manage Roles', 'group_name' => 'RBAC'],
+            ['name' => 'permissions:manage', 'display_name' => 'Manage Permissions', 'group_name' => 'RBAC'],
+        ];
+
+        foreach ($permissions as $permissionData) {
+            Permission::updateOrCreate(['name' => $permissionData['name']], $permissionData);
+        }
+    }
+}

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Role;
+use Illuminate\Support\Facades\DB;
+
+class RolesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reset table if needed, or use updateOrCreate
+        // DB::statement('SET FOREIGN_KEY_CHECKS=0;'); // Disable foreign key checks for certain DBs
+        // Role::truncate(); // Careful with truncate in production or if other tables depend on it without cascade
+        // DB::statement('SET FOREIGN_KEY_CHECKS=1;'); // Re-enable
+
+        $roles = [
+            [
+                'name' => 'super-admin',
+                'display_name' => 'Super Administrator',
+                'description' => 'User with full access to all system features and data.'
+            ],
+            [
+                'name' => 'company-admin',
+                'display_name' => 'Company Administrator',
+                'description' => 'User managing a specific company, its sites, barriers, vehicles, and users.'
+            ],
+            [
+                'name' => 'site-manager',
+                'display_name' => 'Site Manager',
+                'description' => 'User managing specific sites within a company, including barriers and vehicle permissions for those sites.'
+            ],
+            // Add a basic user role if needed in the future, e.g., for viewing only
+            // [
+            //     'name' => 'base-user',
+            //     'display_name' => 'Base User',
+            //     'description' => 'User with basic access, e.g., view own profile.'
+            // ],
+        ];
+
+        foreach ($roles as $roleData) {
+            Role::updateOrCreate(['name' => $roleData['name']], $roleData);
+        }
+    }
+}


### PR DESCRIPTION
Este commit introduz a estrutura base para o Controlo de Acesso Baseado em Papéis (RBAC) e a funcionalidade inicial de gestão de utilizadores.

Alterações Principais:

1.  **Estrutura RBAC:**
    *   Definição de papéis (super-admin, company-admin, site-manager) e permissões granulares.
    *   Criação de migrations para tabelas `roles`, `permissions`, `role_user`, `permission_role`, e adição de `company_id` a `users`.
    *   Criação dos modelos `Role`, `Permission`, e atualização de `User`, `Company` com relações e helpers RBAC.
    *   Criação de seeders para popular dados RBAC (papéis, permissões, associações, super-admin user).

2.  **Autorização:**
    *   Configurado `AuthServiceProvider` com `Gate::before` para super-admin e Gates dinâmicos para outras permissões.
    *   Aplicada autorização (`$this->authorize()`) e lógica de propriedade nos controladores: `CompanyController`, `SiteController`, `BarrierController`, `VehicleController`.

3.  **Escopo de Dados:**
    *   Adaptadas as queries nos métodos `index` de `CompanyController`, `SiteController`, `BarrierController` para filtrar dados com base no papel e `company_id` do utilizador.
    *   Listas de entidades para filtros e formulários (ex: empresas, sites para seleção) também respeitam o escopo.

4.  **Gestão de Utilizadores (Inicial):**
    *   Criado `UserController` com CRUD básico, lógica de autorização e escopo para SuperAdmin e CompanyAdmin (gerir SiteManagers).
    *   Adicionada rota para `users`.
    *   Criadas views Blade: `users/index`, `users/_form`, `users/create`.

Trabalho em progresso: A view `users/edit.blade.php` e partials de mensagens de UI ainda precisam ser criados. A interface de utilizador para gestão de papéis/permissões em si (para SuperAdmin) não foi iniciada.