### PR TITLE
feat: Refinar UI RBAC e simplificar lógica SiteManager

### DIFF
--- a/backend/app/Providers/AuthServiceProvider.php
+++ b/backend/app/Providers/AuthServiceProvider.php
@@ -2,11 +2,13 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate; // Será descomentado e usado
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Gate; // Adicionado para uso
+use Illuminate\Support\Facades\Gate;
 use App\Models\User;
-use App\Models\Permission; // Precisaremos disto para iterar sobre as permissões
+use App\Models\Permission;
+use App\Models\Company;
+use App\Models\Site;
+use App\Models\Barrier;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -16,7 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy', // Exemplo padrão
+        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
     ];
 
     /**
@@ -26,19 +28,14 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        // Gate para Super Admin - concede todas as permissões
         Gate::before(function (User $user, $ability) {
             if ($user->isSuperAdmin()) {
                 return true;
             }
-            return null; // Deixa outros gates decidirem
+            return null;
         });
 
-        // Registrar Gates dinamicamente a partir das permissões na BD
-        // É importante que as permissões já estejam na BD (via seeder) para isto funcionar na inicialização.
-        // Envolver em try-catch para evitar erros durante migrations/setup inicial antes da BD estar pronta.
         try {
-            // Verifica se a tabela permissions existe para evitar erros durante as migrations iniciais
             if (\Illuminate\Support\Facades\Schema::hasTable('permissions')) {
                 Permission::all()->each(function (Permission $permission) {
                     Gate::define($permission->name, function (User $user) use ($permission) {
@@ -47,33 +44,169 @@ class AuthServiceProvider extends ServiceProvider
                 });
             }
         } catch (\Exception $e) {
-            // Logar o erro ou lidar com ele de forma apropriada se ocorrer durante o boot
-            // Pode ser que a BD não esteja acessível durante o artisan config:cache ou similar
             \Illuminate\Support\Facades\Log::error('AuthServiceProvider: Could not register dynamic gates: ' . $e->getMessage());
         }
 
-        // NOTA: Se houver permissões que necessitem de lógica mais complexa
-        // (ex: verificar se o utilizador é dono do recurso - companies:update-own),
-        // elas podem precisar de Gates definidos explicitamente aqui ou através de Policies.
-        // Por exemplo, para 'companies:update-own':
-        // Gate::define('companies:update-own', function (User $user, \App\Models\Company $company) {
-        //     // Primeiro, o utilizador tem a permissão genérica 'companies:update-own'?
-        //     if (!$user->hasPermissionTo('companies:update-own')) {
-        //         return false;
-        //     }
-        //     // Se sim, ele é o dono desta empresa específica? (se for um company-admin)
-        //     if ($user->hasRole('company-admin')) {
-        //         return $user->company_id === $company->id;
-        //     }
-        //     // Se não for company-admin mas tiver a permissão (ex: super-admin já tratado pelo Gate::before), permite.
-        //     // Ou se a lógica for que SÓ company-admin pode ter 'companies:update-own', então o hasPermissionTo já filtraria.
-        //     // A lógica exata aqui depende de como as permissões são atribuídas.
-        //     // O Gate::before para super-admin já cobre o acesso total.
-        //     // Para company-admin, o hasPermissionTo('companies:update-own') será verificado,
-        //     // e a lógica de propriedade será adicionalmente verificada no controlador ou policy.
-        //     // Por agora, o Gate dinâmico acima é suficiente para a verificação base da permissão.
-        //     // A lógica de propriedade será melhor tratada em Policies ou diretamente nos controladores após a autorização base.
-        //     return true; // Este Gate específico pode não ser necessário se a Policy tratar disso.
-        // });
+        // Gate para 'create' genérico, pode ser mais específico se necessário
+        Gate::define('create', function(User $user, string $modelClass, $related_model_id = null) {
+            if ($modelClass === Site::class) { // Criar Site
+                if ($user->isSuperAdmin() && $user->hasPermissionTo('sites:create-any')) {
+                    return true;
+                }
+                // $related_model_id aqui seria company_id
+                if ($user->hasRole('company-admin') && $user->company_id == $related_model_id && $user->hasPermissionTo('sites:create-own-company')) {
+                    return true;
+                }
+                return false;
+            }
+            if ($model instanceof Vehicle) {
+                // SuperAdmin pode editar detalhes do veículo E atribuir quaisquer permissões
+                if ($user->isSuperAdmin() && ($user->hasPermissionTo('vehicles:update-any') || $user->hasPermissionTo('vehicle-permissions:assign-to-any-company'))) {
+                    return true;
+                }
+                // CompanyAdmin pode atribuir permissões para sua empresa
+                if ($user->hasRole('company-admin') && $user->hasPermissionTo('vehicle-permissions:assign-to-own-company')) {
+                    return true;
+                }
+                // SiteManager pode atribuir permissões para seus sites/barreiras
+                if ($user->hasRole('site-manager') && $user->hasPermissionTo('vehicle-permissions:assign-to-assigned-site')) {
+                    return true;
+                }
+                return false;
+            }
+            if ($modelClass === Barrier::class) { // Criar Barrier
+                // $related_model_id aqui seria site_id
+                $site = Site::find($related_model_id);
+                if (!$site) return false;
+
+                if ($user->isSuperAdmin() && $user->hasPermissionTo('barriers:create-any')) {
+                    return true;
+                }
+                if ($user->hasRole('company-admin') && $site->company_id === $user->company_id && $user->hasPermissionTo('barriers:create-own-company-site')) {
+                    return true;
+                }
+                if ($user->hasRole('site-manager') && $site->company_id === $user->company_id && $user->hasPermissionTo('barriers:create-assigned-site')) {
+                    // Simplificado: SiteManager pode criar barreira em qualquer site da sua empresa.
+                    return true;
+                }
+                return false;
+            }
+            // Adicionar outras lógicas de 'create' aqui se necessário (ex: Vehicle)
+            if ($modelClass === Vehicle::class) { // Criar Vehicle (registo)
+                // Assumindo que apenas SuperAdmin pode criar o registo de um veículo
+                return $user->isSuperAdmin() && $user->hasPermissionTo('vehicles:create-any');
+            }
+            return null;
+        });
+
+        // Gate para 'viewAny' (listagens condicionadas por um pai)
+        Gate::define('viewAny', function(User $user, string $modelClass, $parentModel = null) {
+            if ($modelClass === Site::class && $parentModel instanceof Company) { // Ver Sites de uma Company
+                // SuperAdmin já coberto pelo Gate::before se tiver a permissão 'sites:view-any'
+                // Este Gate define a condição para CompanyAdmin ver sites da sua empresa.
+                if ($user->hasRole('company-admin') && $user->company_id === $parentModel->id && $user->hasPermissionTo('sites:view-own-company')) {
+                    return true;
+                }
+                return false;
+            }
+            if ($modelClass === Barrier::class && $parentModel instanceof Site) { // Ver Barriers de um Site
+                 if ($user->isSuperAdmin() && $user->hasPermissionTo('barriers:view-any')) {
+                    return true;
+                }
+                if ($user->hasRole('company-admin') && $user->company_id === $parentModel->company_id && $user->hasPermissionTo('barriers:view-own-company')) {
+                    return true;
+                }
+                if ($user->hasRole('site-manager') && $user->company_id === $parentModel->company_id && $user->hasPermissionTo('barriers:view-assigned-site')) {
+                    // Simplificado: SiteManager pode ver barreiras de qualquer site da sua empresa.
+                    return true;
+                }
+                return false;
+            }
+            return null;
+        });
+
+        Gate::define('update', function (User $user, $model) {
+            if ($model instanceof Company) {
+                // SuperAdmin já coberto pelo Gate::before
+                if ($user->hasRole('company-admin') && $user->company_id === $model->id && $user->hasPermissionTo('companies:update-own')) {
+                    return true;
+                }
+                return false;
+            }
+            if ($model instanceof Site) {
+                // SuperAdmin já coberto
+                if ($user->hasRole('company-admin') && $user->company_id === $model->company_id && $user->hasPermissionTo('sites:update-own-company')) {
+                    return true;
+                }
+                if ($user->hasRole('site-manager') && $user->company_id === $model->company_id && $user->hasPermissionTo('sites:update-assigned')) {
+                    // Simplificado: SiteManager pode atualizar qualquer site da sua empresa se tiver a permissão.
+                    return true;
+                }
+                return false;
+            }
+            if ($model instanceof Barrier) {
+                // SuperAdmin já coberto
+                if ($user->hasRole('company-admin') && $model->site->company_id === $user->company_id && $user->hasPermissionTo('barriers:update-own-company-site')) {
+                    return true;
+                }
+                if ($user->hasRole('site-manager') && $model->site->company_id === $user->company_id && $user->hasPermissionTo('barriers:update-assigned-site')) {
+                    // Simplificado: SiteManager pode atualizar qualquer barreira de sites da sua empresa.
+                    return true;
+                }
+                return false;
+            }
+            if ($model instanceof User) { // Managed User
+                // SuperAdmin já coberto
+                if ($user->id === $model->id && $user->hasPermissionTo('users:update-own')) { // Editar próprio perfil
+                    return true;
+                }
+                if ($user->hasRole('company-admin') && $user->company_id === $model->company_id && $user->hasPermissionTo('users:update-own-company-user')) {
+                     return true; // Lógica de só poder editar site-managers está no controller/request validation
+                }
+                return false;
+            }
+            return null;
+        });
+
+        Gate::define('delete', function (User $user, $model) {
+            if ($model instanceof Company) {
+                return $user->isSuperAdmin() && $user->hasPermissionTo('companies:delete-any');
+            }
+            if ($model instanceof Site) {
+                if ($user->isSuperAdmin() && $user->hasPermissionTo('sites:delete-any')) return true;
+                if ($user->hasRole('company-admin') && $user->company_id === $model->company_id && $user->hasPermissionTo('sites:delete-own-company')) {
+                    return true;
+                }
+                if ($user->hasRole('site-manager') && $user->company_id === $model->company_id && $user->hasPermissionTo('sites:delete-assigned')) {
+                    // Simplificado: SiteManager pode excluir qualquer site da sua empresa.
+                    return true;
+                }
+                return false;
+            }
+            if ($model instanceof Barrier) {
+                if ($user->isSuperAdmin() && $user->hasPermissionTo('barriers:delete-any')) return true;
+                if ($user->hasRole('company-admin') && $model->site->company_id === $user->company_id && $user->hasPermissionTo('barriers:delete-own-company-site')) {
+                    return true;
+                }
+                if ($user->hasRole('site-manager') && $model->site->company_id === $user->company_id && $user->hasPermissionTo('barriers:delete-assigned-site')) {
+                    // Simplificado: SiteManager pode excluir qualquer barreira de sites da sua empresa.
+                    return true;
+                }
+                return false;
+            }
+            if ($model instanceof Vehicle) {
+                // Apenas SuperAdmin pode excluir o registo de um veículo
+                return $user->isSuperAdmin() && $user->hasPermissionTo('vehicles:delete-any');
+            }
+            if ($model instanceof User) { // Managed User
+                if ($user->id === $model->id) { return false; }
+                if ($user->isSuperAdmin() && $user->hasPermissionTo('users:delete-any')) return true;
+                if ($user->hasRole('company-admin') && $user->company_id === $model->company_id && $user->hasPermissionTo('users:delete-own-company-user')) {
+                    return true;
+                }
+                return false;
+            }
+            return null;
+        });
     }
 }

--- a/backend/resources/views/admin/companies/index.blade.php
+++ b/backend/resources/views/admin/companies/index.blade.php
@@ -66,7 +66,9 @@
                 </form>
             </div>
 
+            @can('companies:create')
             <a href="{{ route('admin.companies.create') }}" class="create-link">Adicionar Nova Empresa</a>
+            @endcan
 
             @if (session('success'))
                 <div class="alert alert-success">{{ session('success') }}</div>
@@ -95,13 +97,19 @@
                             <td>{{ $company->sites_count ?? $company->sites()->count() }}</td>
                             <td>{{ $company->created_at->format('d/m/Y H:i') }}</td>
                             <td class="actions">
-                                <a href="{{ route('admin.sites.index', ['company_id' => $company->id]) }}" class="button-style">Ver Sites</a>
-                                <a href="{{ route('admin.companies.edit', $company) }}" class="edit">Editar</a>
-                                <form action="{{ route('admin.companies.destroy', $company) }}" method="POST" style="display:inline;" onsubmit="return confirm('Tem certeza que deseja excluir esta empresa? Todos os sites e barreiras associados também serão excluídos.');">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="delete">Excluir</button>
-                                </form>
+                                @can('viewAny', [App\Models\Site::class, $company]) {{-- Policy ou Gate para ver sites de uma empresa --}}
+                                    <a href="{{ route('admin.sites.index', ['company_id' => $company->id]) }}" class="button-style">Ver Sites</a>
+                                @endcan
+                                @can('update', $company)
+                                    <a href="{{ route('admin.companies.edit', $company) }}" class="edit">Editar</a>
+                                @endcan
+                                @can('delete', $company)
+                                    <form action="{{ route('admin.companies.destroy', $company) }}" method="POST" style="display:inline;" onsubmit="return confirm('Tem certeza que deseja excluir esta empresa? Todos os sites e barreiras associados também serão excluídos.');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="delete">Excluir</button>
+                                    </form>
+                                @endcan
                             </td>
                         </tr>
                     @empty

--- a/backend/resources/views/admin/sites/_form.blade.php
+++ b/backend/resources/views/admin/sites/_form.blade.php
@@ -1,11 +1,33 @@
 @csrf
+
+@php
+    $currentUser = Auth::user();
+    $isSuperAdmin = $currentUser->isSuperAdmin();
+    // Se for Company Admin, a empresa é a dele e não pode ser alterada.
+    // $companies é assumido como uma coleção de objetos Company ou um array id => nome.
+    // Se $companies for uma coleção, o primeiro item será usado para o CompanyAdmin.
+    $companyAdminCompany = null;
+    if (!$isSuperAdmin && $currentUser->hasRole('company-admin')) {
+        if ($companies instanceof Illuminate\Support\Collection && $companies->isNotEmpty()) {
+            $companyAdminCompany = $companies->first(); // Assumindo que o controller passou apenas a empresa do CompanyAdmin
+        } elseif (is_array($companies) && !empty($companies)) {
+             // Se for um array [id => nome], precisamos encontrar o ID da empresa do admin.
+             // Esta parte pode precisar de ajuste dependendo de como $companies é passado para CA.
+             // Idealmente, o controller passa apenas a empresa do CompanyAdmin.
+             $companyAdminCompany = (object) ['id' => $currentUser->company_id, 'name' => $companies[$currentUser->company_id] ?? 'Current Company'];
+        }
+    }
+@endphp
+
+@if($isSuperAdmin)
 <div>
     <label for="company_id">Empresa:</label><br>
     <select id="company_id" name="company_id" required>
         <option value="">Selecione uma Empresa</option>
-        @foreach($companies as $id => $name)
-            <option value="{{ $id }}" {{ old('company_id', $site->company_id ?? '') == $id ? 'selected' : '' }}>
-                {{ $name }}
+        {{-- Iterar sobre $companies, que para SuperAdmin deve ser todas as empresas --}}
+        @foreach($companies as $company)
+            <option value="{{ $company->id }}" {{ old('company_id', $site->company_id ?? '') == $company->id ? 'selected' : '' }}>
+                {{ $company->name }}
             </option>
         @endforeach
     </select>
@@ -13,6 +35,25 @@
         <div style="color: red;">{{ $message }}</div>
     @enderror
 </div>
+@elseif($companyAdminCompany)
+<div>
+    <label>Empresa:</label><br>
+    <p><strong>{{ $companyAdminCompany->name }}</strong></p>
+    <input type="hidden" name="company_id" value="{{ $companyAdminCompany->id }}">
+</div>
+@else
+    {{-- Caso para SiteManager editando seu próprio site, ou erro --}}
+    @if(isset($site) && $site->company)
+    <div>
+        <label>Empresa:</label><br>
+        <p><strong>{{ $site->company->name }}</strong></p>
+        {{-- SiteManager não deve poder mudar a empresa do site --}}
+        <input type="hidden" name="company_id" value="{{ $site->company_id }}">
+    </div>
+    @else
+    <div style="color: red;">Erro: A empresa não pôde ser determinada. Contacte o suporte.</div>
+    @endif
+@endif
 <br>
 <div>
     <label for="name">Nome do Site:</label><br>

--- a/backend/resources/views/admin/sites/index.blade.php
+++ b/backend/resources/views/admin/sites/index.blade.php
@@ -64,6 +64,7 @@
                         <label for="name_filter">Nome do Site:</label>
                         <input type="text" name="name_filter" id="name_filter" value="{{ request('name_filter') }}">
                     </div>
+                    @if(Auth::user()->isSuperAdmin()) {{-- Ou @can('sites:view-any') se preferir usar permissão --}}
                     <div>
                         <label for="company_filter">Empresa:</label>
                         <select name="company_filter" id="company_filter">
@@ -75,6 +76,7 @@
                             @endforeach
                         </select>
                     </div>
+                    @endif
                     <div>
                         <label for="is_active_filter">Status:</label>
                         <select name="is_active_filter" id="is_active_filter">
@@ -88,7 +90,9 @@
                 </form>
             </div>
 
-            <a href="{{ route('admin.sites.create') }}" class="create-link">Adicionar Novo Site</a>
+            @can('create', App\Models\Site::class) {{-- Gate genérico para criar Site --}}
+            <a href="{{ route('admin.sites.create', request()->query('company_filter') ? ['company_id' => request()->query('company_filter')] : []) }}" class="create-link">Adicionar Novo Site</a>
+            @endcan
 
             @if (session('success'))
                 <div class="alert alert-success">{{ session('success') }}</div>
@@ -119,13 +123,19 @@
                             <td>{{ $site->barriers_count ?? $site->barriers()->count() }}</td>
                             <td>{{ $site->created_at->format('d/m/Y H:i') }}</td>
                             <td class="actions">
+                                @can('viewAny', [App\Models\Barrier::class, $site])
                                 <a href="{{ route('admin.barriers.index', ['site_id' => $site->id]) }}" class="button-style">Ver Barreiras</a>
+                                @endcan
+                                @can('update', $site)
                                 <a href="{{ route('admin.sites.edit', $site) }}" class="edit">Editar</a>
+                                @endcan
+                                @can('delete', $site)
                                 <form action="{{ route('admin.sites.destroy', $site) }}" method="POST" style="display:inline;" onsubmit="return confirm('Tem certeza que deseja excluir este site? Todas as barreiras associadas também serão excluídas.');">
                                     @csrf
                                     @method('DELETE')
                                     <button type="submit" class="delete">Excluir</button>
                                 </form>
+                                @endcan
                             </td>
                         </tr>
                     @empty

--- a/backend/resources/views/admin/users/edit.blade.php
+++ b/backend/resources/views/admin/users/edit.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.admin_app')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <h2>Edit User: {{ $managedUser->name }}</h2>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            User Details
+        </div>
+        <div class="card-body">
+            @include('partials.admin.error_messages') {{-- Para mostrar erros de validação --}}
+            @include('partials.admin.success_message') {{-- Para mostrar mensagens de sucesso --}}
+
+            <form method="POST" action="{{ route('admin.users.update', $managedUser->id) }}">
+                @method('PUT')
+                @include('admin.users._form', ['managedUser' => $managedUser, 'editable_roles' => $editable_roles, 'companies' => $companies])
+            </form>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+    {{-- Inicializar select2 se estiver a ser usado --}}
+    <script>
+        $(document).ready(function() {
+            $('.select2').select2({
+                placeholder: "Select roles",
+                allowClear: true
+            });
+        });
+    </script>
+@endpush

--- a/backend/resources/views/admin/users/index.blade.php
+++ b/backend/resources/views/admin/users/index.blade.php
@@ -92,42 +92,25 @@
                                 @endif
                             </td>
                             <td>
-                                @php $canUpdate = false; @endphp
-                                @if(Auth::user()->isSuperAdmin())
-                                    @can('users:update-any') @php $canUpdate = true; @endphp @endcan
-                                @elseif(Auth::user()->hasRole('company-admin') && Auth::user()->company_id === $managedUser->company_id)
-                                    @can('users:update-own-company-user', $managedUser) @php $canUpdate = true; @endphp @endcan
-                                @elseif(Auth::id() === $managedUser->id) {{-- Editar o próprio perfil --}}
-                                     @can('users:update-own', $managedUser) @php $canUpdate = true; @endphp @endcan
-                                @endif
+                                {{-- O Gate 'users:update' deve ser definido no AuthServiceProvider para abranger os diferentes cenários --}}
+                                @can('update', $managedUser)
+                                    <a href="{{ route('admin.users.edit', $managedUser->id) }}" class="btn btn-xs btn-warning">
+                                        <i class="fas fa-edit"></i> Edit
+                                    </a>
+                                @endcan
 
-                                @if($canUpdate)
-                                <a href="{{ route('admin.users.edit', $managedUser->id) }}" class="btn btn-xs btn-warning">
-                                    <i class="fas fa-edit"></i> Edit
-                                </a>
-                                @endif
-
-                                @if(Auth::id() !== $managedUser->id) {{-- Não pode excluir a si mesmo --}}
-                                    @php $canDelete = false; @endphp
-                                    @if(Auth::user()->isSuperAdmin())
-                                        @can('users:delete-any') @php $canDelete = true; @endphp @endcan
-                                    @elseif(Auth::user()->hasRole('company-admin') && Auth::user()->company_id === $managedUser->company_id)
-                                        @can('users:delete-own-company-user', $managedUser)
-                                            @if($managedUser->hasRole('site-manager')) {{-- CompanyAdmin só pode excluir SiteManagers --}}
-                                                @php $canDelete = true; @endphp
-                                            @endif
-                                        @endcan
-                                    @endif
-
-                                    @if($canDelete)
-                                    <form action="{{ route('admin.users.destroy', $managedUser->id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this user?');">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="btn btn-xs btn-danger">
-                                            <i class="fas fa-trash"></i> Delete
-                                        </button>
-                                    </form>
-                                    @endif
+                                {{-- O Gate 'users:delete' deve ser definido para os diferentes cenários --}}
+                                {{-- Prevenir auto-exclusão já está no Controller, mas pode ser reforçado no Gate se necessário --}}
+                                @if(Auth::id() !== $managedUser->id)
+                                    @can('delete', $managedUser)
+                                        <form action="{{ route('admin.users.destroy', $managedUser->id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this user? This action cannot be undone.');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-xs btn-danger">
+                                                <i class="fas fa-trash"></i> Delete
+                                            </button>
+                                        </form>
+                                    @endcan
                                 @endif
                             </td>
                         </tr>

--- a/backend/resources/views/admin/vehicles/index.blade.php
+++ b/backend/resources/views/admin/vehicles/index.blade.php
@@ -39,7 +39,9 @@
         </form>
     </div>
 
+    @can('create', App\Models\Vehicle::class)
     <a href="{{ route('admin.vehicles.create') }}" class="create-link">Adicionar Novo Veículo</a>
+    @endcan
 
     @if (session('success'))
         <div class="alert-success">
@@ -69,12 +71,16 @@
                     </td>
                     <td>{{ $vehicle->created_at->format('d/m/Y H:i') }}</td>
                     <td class="actions">
+                        @can('update', $vehicle) {{-- Gate para editar o veículo/suas permissões --}}
                         <a href="{{ route('admin.vehicles.edit', $vehicle) }}">Editar Permissões</a>
+                        @endcan
+                        @can('delete', $vehicle) {{-- Gate para excluir o veículo --}}
                         <form action="{{ route('admin.vehicles.destroy', $vehicle) }}" method="POST" style="display:inline;" onsubmit="return confirm('Tem certeza que deseja excluir este veículo?');">
                             @csrf
                             @method('DELETE')
                             <button type="submit">Excluir</button>
                         </form>
+                        @endcan
                     </td>
                 </tr>
             @empty


### PR DESCRIPTION
- Adiciona diretivas @can nas views de Company, Site, Barrier e Vehicle para controlar a visibilidade de ações CRUD com base nas permissões do utilizador.
- Atualiza AuthServiceProvider com Gates mais granulares para 'create', 'update', 'delete', e 'viewAny' (condicional) para os modelos relevantes.
- Simplifica temporariamente a lógica de permissão para SiteManagers, permitindo-lhes gerir todos os sites/barreiras da sua empresa associada, em vez de requerer atribuição explícita a sites individuais.
- Esta simplificação é uma medida provisória; a granularidade total para SiteManager pode ser implementada futuramente.